### PR TITLE
Allow to choose online math rendering service for "Save as Markdown"

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,16 @@
                     ],
                     "type": "array"
                 },
+                "markdown-preview-enhanced.saveAsMarkdown.mathRenderingOnLineService": {
+                    "description": "Choose the Math expression rendering method option for GFM markdown export (Save as Markdown).",
+                    "default": "https://latex.codecogs.com/gif.latex",
+                    "type": "string",
+                    "enum": [
+                        "https://latex.codecogs.com/gif.latex",
+                        "https://latex.codecogs.com/svg.latex",
+                        "https://latex.codecogs.com/png.latex"
+                    ]
+                },
                 "markdown-preview-enhanced.enableWikiLinkSyntax": {
                     "description": "Enable Wiki Link syntax support. More information can be found at https://help.github.com/articles/adding-links-to-wikis/",
                     "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,9 @@ export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
     ) as MathRenderingOption;
     this.mathInlineDelimiters = config.get<string[][]>("mathInlineDelimiters");
     this.mathBlockDelimiters = config.get<string[][]>("mathBlockDelimiters");
-    this.mathRenderingOnLineService = config.get<string>("saveAsMarkdown.mathRenderingOnLineService");
+    this.mathRenderingOnLineService = config.get<string>(
+      "saveAsMarkdown.mathRenderingOnLineService",
+    );
     this.codeBlockTheme = config.get<string>("codeBlockTheme");
     this.previewTheme = config.get<string>("previewTheme");
     this.revealjsTheme = config.get<string>("revealjsTheme");

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
   public readonly mathRenderingOption: MathRenderingOption;
   public readonly mathInlineDelimiters: string[][];
   public readonly mathBlockDelimiters: string[][];
+  public readonly mathRenderingOnLineService: string;
   public readonly codeBlockTheme: string;
   public readonly mermaidTheme: string;
   public readonly previewTheme: string;
@@ -68,6 +69,7 @@ export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
     ) as MathRenderingOption;
     this.mathInlineDelimiters = config.get<string[][]>("mathInlineDelimiters");
     this.mathBlockDelimiters = config.get<string[][]>("mathBlockDelimiters");
+    this.mathRenderingOnLineService = config.get<string>("saveAsMarkdown.mathRenderingOnLineService");
     this.codeBlockTheme = config.get<string>("codeBlockTheme");
     this.previewTheme = config.get<string>("previewTheme");
     this.revealjsTheme = config.get<string>("revealjsTheme");


### PR DESCRIPTION
To be used with a pull request on mume (https://github.com/shd101wyy/mume/pull/114)
This PR to allow to choose the math on line service rendering in mume, from the vscode extentions settings.

Refs: https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/189