### PR TITLE
add KaTeX parser support for GitLab Flavored Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,10 @@
                     "description": "Use customized Math expression inline delimiters.",
                     "default": [
                         [
+                            "$`",
+                            "`$"
+                        ],
+                        [
                             "$",
                             "$"
                         ],
@@ -223,6 +227,10 @@
                 "markdown-preview-enhanced.mathBlockDelimiters": {
                     "description": "Use customized Math expression block delimiters.",
                     "default": [
+                        [
+                            "```math",
+                            "```"
+                        ],
                         [
                             "$$",
                             "$$"


### PR DESCRIPTION
GitLab Flavored Markdown requires `` $` `` and `` `$ `` for inline equation delimiters, `` ```math `` and `` ``` `` for block equation delimiters. `` $` `` and `` `$ `` must be placed in front of `$` and `$` or the parser will throw errors.