### PR TITLE
Fix automatically show preivew not working

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -522,14 +522,15 @@ export function activate(context: vscode.ExtensionContext) {
                 preserveFocus: true,
               });
             } else if (
-              !isUsingSinglePreview &&
-              automaticallyShowPreviewOfMarkdownBeingEdited
+              !isUsingSinglePreview
             ) {
               const previewPanel = contentProvider.getPreview(sourceUri);
               if (previewPanel) {
                 previewPanel.reveal(vscode.ViewColumn.Two, true);
               }
             }
+          } else if (automaticallyShowPreviewOfMarkdownBeingEdited) {
+            openPreviewToTheSide(sourceUri);
           }
         }
       }


### PR DESCRIPTION
Automatically show preview feature seems broken. Here's a suggested fix, simply tested on Windows VS Code 1.34.0.

Tested behaviours:

- **Single preview true & auto show preview true**: 
  - if there is no preview when opening an md file, show the preview automatically
  - if there is already preview, change the preview when the active markdown file changes

- **Single preview true & auto show preview false**:
  - if there is no preview when opening an md file, do not show the preview automatically
  - if there is already preview,change the preview when the active markdown file changes (*not sure if this is an expected behaviour*)

- **Single preview false & auto show preview true**:
  - if there is no preview when opening an md file, open the preview tab automatically
  - if there are any other previews, show a new preview tab when open a new markdown file
  - if there is an inactive preview tab of the editing markdown file, switch to that preview tab

- **Single preview false & auto show preview false**:
  - if there is no preview tab of the editing md file, do not open the preview tab automatically
  - if there is an inactive preview tab of the editing markdown file, switch to that preview tab (*not sure if this is an expected behaviour*)