### PR TITLE
allow gitlab flavored inline math per default

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,6 +255,10 @@
           "description": "Use customized Math expression inline delimiters.",
           "default": [
             [
+              "$`",
+              "`$"
+            ],
+            [
               "$",
               "$"
             ],


### PR DESCRIPTION
add the tags for inline math used by gitlab markdown

minimal version of: https://github.com/shd101wyy/vscode-markdown-preview-enhanced/pull/223

