### PR TITLE
Support project configuration

### DIFF
--- a/src/preview-content-provider.ts
+++ b/src/preview-content-provider.ts
@@ -45,10 +45,28 @@ export class MarkdownPreviewEnhancedView {
   private config: MarkdownPreviewEnhancedConfig;
 
   public constructor(private context: vscode.ExtensionContext) {
+    this.updateObject();
+  }
+
+  public updateObject() {
     this.config = MarkdownPreviewEnhancedConfig.getCurrentConfig();
 
+    var projectDirectoryPath = vscode.workspace.getWorkspaceFolder(
+      vscode.window.activeTextEditor.document.uri,
+    ).uri.fsPath;
+
+    if (projectDirectoryPath == undefined) {
+      return;
+    }
+
+    var configPath = path.resolve(
+      this.config.configPath
+        .replace("${projectDir}", projectDirectoryPath)
+        .replace("${workspaceFolder}", projectDirectoryPath),
+    );
+
     mume
-      .init(this.config.configPath) // init markdown-preview-enhanced
+      .init(configPath) // init markdown-preview-enhanced
       .then(() => {
         mume.onDidChangeConfigFile(this.refreshAllPreviews.bind(this));
         MarkdownEngine.onModifySource(this.modifySource.bind(this));
@@ -378,6 +396,8 @@ export class MarkdownPreviewEnhancedView {
     editor: vscode.TextEditor,
     viewOptions: { viewColumn: vscode.ViewColumn; preserveFocus?: boolean },
   ) {
+    this.updateObject();
+
     const isUsingSinglePreview = useSinglePreview();
     let previewPanel: vscode.WebviewPanel;
     if (isUsingSinglePreview && this.singlePreviewPanel) {

--- a/src/preview-content-provider.ts
+++ b/src/preview-content-provider.ts
@@ -59,11 +59,14 @@ export class MarkdownPreviewEnhancedView {
       return;
     }
 
-    var configPath = path.resolve(
-      this.config.configPath
-        .replace("${projectDir}", projectDirectoryPath)
-        .replace("${workspaceFolder}", projectDirectoryPath),
-    );
+    var configPath =
+      this.config.configPath == ""
+        ? ""
+        : path.resolve(
+            this.config.configPath
+              .replace("${projectDir}", projectDirectoryPath)
+              .replace("${workspaceFolder}", projectDirectoryPath),
+          );
 
     mume
       .init(configPath) // init markdown-preview-enhanced

--- a/src/preview-content-provider.ts
+++ b/src/preview-content-provider.ts
@@ -394,8 +394,6 @@ export class MarkdownPreviewEnhancedView {
     editor: vscode.TextEditor,
     viewOptions: { viewColumn: vscode.ViewColumn; preserveFocus?: boolean },
   ) {
-    this.updateObject();
-
     const isUsingSinglePreview = useSinglePreview();
     let previewPanel: vscode.WebviewPanel;
     if (isUsingSinglePreview && this.singlePreviewPanel) {
@@ -411,6 +409,7 @@ export class MarkdownPreviewEnhancedView {
         ) || path.dirname(sourceUri.fsPath);
       if (oldResourceRoot !== newResourceRoot) {
         this.singlePreviewPanel.dispose();
+        this.updateObject();
         return this.initPreview(sourceUri, editor, viewOptions);
       } else {
         previewPanel = this.singlePreviewPanel;

--- a/src/preview-content-provider.ts
+++ b/src/preview-content-provider.ts
@@ -50,23 +50,18 @@ export class MarkdownPreviewEnhancedView {
 
   public updateObject() {
     this.config = MarkdownPreviewEnhancedConfig.getCurrentConfig();
-
-    var projectDirectoryPath = vscode.workspace.getWorkspaceFolder(
-      vscode.window.activeTextEditor.document.uri,
+    const projectDirectoryPath = vscode.workspace.getWorkspaceFolder(
+      vscode.window.activeTextEditor?.document?.uri,
     ).uri.fsPath;
 
-    if (projectDirectoryPath == undefined) {
-      return;
+    let configPath: string = this.config.configPath;
+    if (configPath != "" && projectDirectoryPath != undefined) {
+      configPath = path.resolve(
+        configPath
+          .replace("${projectDir}", projectDirectoryPath)
+          .replace("${workspaceFolder}", projectDirectoryPath),
+      );
     }
-
-    var configPath =
-      this.config.configPath == ""
-        ? ""
-        : path.resolve(
-            this.config.configPath
-              .replace("${projectDir}", projectDirectoryPath)
-              .replace("${workspaceFolder}", projectDirectoryPath),
-          );
 
     mume
       .init(configPath) // init markdown-preview-enhanced


### PR DESCRIPTION
I want to support different `parser.js` for each project.
I saw [this](https://github.com/shd101wyy/mume/pull/181), and after looking at the source code, I understood its difficulty.
I tried to modify it like this. This allows you to use `${projectDir}` or `${workspaceFolder}` in the configuration to indicate the project path, such as `${workspaceFolder}/.MPE`.(Need to restart vscode).
In my test, it can work normally in single folder mode and workspace mode.
I am not sure if I missed something.

At the same time, you need to cancel the check [here](https://github.com/shd101wyy/mume/blob/7135d7606a6a57de6e2372c26a2f16bb98ecf2b2/src/mume.ts#L26).
