### PR TITLE
jump to line fragment when opening local links

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -392,14 +392,50 @@ export function activate(context: vscode.ExtensionContext) {
     } else if (href.match(/^file:\/\/\//)) {
       // openFilePath = href.slice(8) # remove protocol
       let openFilePath = utility.addFileProtocol(
-        href.replace(/(\s*)[\#\?](.+)$/, ""),
+        href.replace(/(\s*)[\?](.+)[\#$]/, ""),
       ); // remove #anchor and ?params...
       openFilePath = decodeURI(openFilePath);
-      vscode.commands.executeCommand(
-        "vscode.open",
-        vscode.Uri.parse(openFilePath),
-        vscode.ViewColumn.One,
-      );
+      let fileUri = vscode.Uri.parse(openFilePath);
+
+      // determine from link fragment to which line to jump
+      let line = -1;
+      let found = fileUri.fragment.match(/^L(\d+)/);
+      if (found) {
+          line = parseInt(found[1]);
+          if (line > 0)
+              line = line - 1;
+      }
+
+      // find if there is already opened such file
+      // and remember in which view column it is
+      let col = vscode.ViewColumn.One;
+      tgrLoop:
+      for (const tabGroup of vscode.window.tabGroups.all) {
+          for (const tab of tabGroup.tabs) {
+              if (tab.input instanceof vscode.TabInputText) {
+                  if (tab.input.uri.path == fileUri.path) {
+                      col = tabGroup.viewColumn;
+                      break tgrLoop;
+                  }
+              }
+          }
+      }
+
+      // open file if needed, if not we will use already opened editor
+      // (by specifying view column in which it is already shown)
+      vscode.workspace.openTextDocument(fileUri.path).then(doc => {
+          vscode.window.showTextDocument(doc, col).then(editor => {
+              // if there was line fragment, jump to line
+              if (line >= 0) {
+                  let viewPos = vscode.TextEditorRevealType.InCenter;
+                  if (editor.selection.active.line == line)
+                      viewPos = vscode.TextEditorRevealType.InCenterIfOutsideViewport;
+                  const sel = new vscode.Selection(line, 0, line, 0);
+                  editor.selection = sel;
+                  editor.revealRange(sel, viewPos);
+              }
+              })
+          });
     } else {
       utility.openFile(href);
     }


### PR DESCRIPTION
Utilize #Lxxx link fragment on links to local files. If file is already opened, existing editor will be used/focused and cursor will be moved to line specified in link fragment.
For that we use openTextDocument and showTextDocument instead of vscode.open. Also we use Tab API that is available from VS Code v1.67.

Resolves shd101wyy/vscode-markdown-preview-enhanced#647