### PR TITLE
Feature predefined variables and environment variables in configPath

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -69,20 +69,49 @@ export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
 
     this.configPath = (config.get<string>("configPath") || "").trim();
     // replace predefined variables in config path
-    // ... workspaceFolder
-    if (this.configPath.includes("${workspaceFolder}")) {
-      if (vscode.workspace.workspaceFolders !== undefined) {
-        // let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.path ;
-        let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    {
+      // ... workspaceFolder
+      if (this.configPath.includes("${workspaceFolder}")) {
+        if (vscode.workspace.workspaceFolders !== undefined) {
+          // determine workspace folder
+          // let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.path ;
+          let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
 
-        this.configPath = this.configPath.replace(
-          "${workspaceFolder}",
-          workspaceFolder,
-        );
-      } else {
-        vscode.window.showErrorMessage(
-          "Working folder not found, open a folder an try again",
-        );
+          // replace in configPath
+          this.configPath = this.configPath.replace(
+            "${workspaceFolder}",
+            workspaceFolder,
+          );
+
+          // log
+          //vscode.window.showInformationMessage(
+          //  `Resolved config (workspace folder): ${this.configPath}`,
+          //);
+        } else {
+          vscode.window.showErrorMessage(
+            "Working folder not found, open a folder an try again",
+          );
+        }
+      }
+    }
+
+    // replace environment variables in config path
+    {
+      // try to replace environment variables for windows (%ENV_VAR%) and bash (${ENV_VAR} as well as $ENV_VAR)
+      // line as suggested in https://stackoverflow.com/questions/21363912/how-to-resolve-a-path-that-includes-an-environment-variable-in-nodejs
+      let resolvedConfigPath = this.configPath.replace(
+        /%([A-Z_]+[A-Z0-9_]*)%|\$([A-Z_]+[A-Z0-9_]*)|\${([A-Z0-9_]*)}/gi,
+        (_, windows, bash1, bash2) => process.env[windows || bash1 || bash2],
+      );
+      // check if something changed
+      if (resolvedConfigPath != this.configPath) {
+        // update config path
+        this.configPath = resolvedConfigPath;
+
+        // log
+        //vscode.window.showInformationMessage(
+        //  `Resolved config (environment variables): ${this.configPath}`,
+        //);
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,24 @@ export class MarkdownPreviewEnhancedConfig implements MarkdownEngineConfig {
     );
 
     this.configPath = (config.get<string>("configPath") || "").trim();
+    // replace predefined variables in config path
+    // ... workspaceFolder
+    if (this.configPath.includes("${workspaceFolder}")) {
+      if (vscode.workspace.workspaceFolders !== undefined) {
+        // let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.path ;
+        let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
+
+        this.configPath = this.configPath.replace(
+          "${workspaceFolder}",
+          workspaceFolder,
+        );
+      } else {
+        vscode.window.showErrorMessage(
+          "Working folder not found, open a folder an try again",
+        );
+      }
+    }
+
     this.usePandocParser = config.get<boolean>("usePandocParser");
     this.breakOnSingleNewLine = config.get<boolean>("breakOnSingleNewLine");
     this.enableTypographer = config.get<boolean>("enableTypographer");


### PR DESCRIPTION
adds support for:
- windows & linux environment variables in configPath, like %ENV_VAR%, ${ENV_VAR} and $ENV_VAR
- vscode predefined variable ${workspaceFolder}
in setting "configPath"

fixes shd101wyy/vscode-markdown-preview-enhanced#625