### PR TITLE
disable auto-preview config for specific URI schemes (for example .ipynb)

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,16 @@
           "default": false,
           "type": "boolean"
         },
+        "markdown-preview-enhanced.disableAutoPreviewForUriSchemes": {
+          "markdownDescription": "A list of URI schemes (e.g., `vscode-notebook-cell`) to exclude from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature. Files matching these schemes won't trigger the automatic preview.",
+          "default": [
+            "vscode-notebook-cell"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "markdown-preview-enhanced.previewColorScheme": {
           "type": "string",
           "enum": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,8 @@ type VSCodeMPEConfigKey =
   | 'qiniuBucket'
   | 'qiniuDomain'
   | 'qiniuSecretKey'
-  | 'scrollSync';
+  | 'scrollSync'
+  | 'disableAutoPreviewForUriSchemes';
 
 type ConfigKey = keyof NotebookConfig | VSCodeMPEConfigKey;
 

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -268,11 +268,11 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
   }
 
   /*
-	function cacheSVG(uri, code, svg) {
-		const sourceUri = vscode.Uri.parse(uri);
-		contentProvider.cacheSVG(sourceUri, code, svg)
-	}
-	*/
+  function cacheSVG(uri, code, svg) {
+    const sourceUri = vscode.Uri.parse(uri);
+    contentProvider.cacheSVG(sourceUri, code, svg)
+  }
+  */
 
   async function cacheCodeChunkResult(uri, id, result) {
     const sourceUri = vscode.Uri.parse(uri);
@@ -884,7 +884,20 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
    */
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(async (editor) => {
+      // Check if editor and document exist
       if (editor && editor.document && editor.document.uri) {
+        // Get the list of schemes to exclude from the configuration
+        const exclusionSchemes =
+          getMPEConfig<string[]>('disableAutoPreviewForUriSchemes') ?? [];
+
+        // Check if the current document's scheme should be excluded
+        for (const scheme of exclusionSchemes) {
+          if (editor.document.uri.scheme.startsWith(scheme)) {
+            return; // Don't trigger preview if scheme matches exclusion list
+          }
+        }
+
+        // Original check: Proceed only if it's considered a Markdown file
         if (isMarkdownFile(editor.document)) {
           const sourceUri = editor.document.uri;
           const automaticallyShowPreviewOfMarkdownBeingEdited = getMPEConfig<
@@ -948,10 +961,10 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
   */
 
   /*
-	context.subscriptions.push(vscode.window.onDidChangeVisibleTextEditors(textEditors=> {
-		// console.log('onDidChangeonDidChangeVisibleTextEditors ', textEditors)
-	}))
-	*/
+  context.subscriptions.push(vscode.window.onDidChangeVisibleTextEditors(textEditors=> {
+    // console.log('onDidChangeonDidChangeVisibleTextEditors ', textEditors)
+  }))
+  */
 
   context.subscriptions.push(
     vscode.commands.registerCommand(


### PR DESCRIPTION
**Problem:**

The `automaticallyShowPreviewOfMarkdownBeingEdited` setting incorrectly triggers previews for Markdown cells in Jupyter notebooks (`.ipynb`), disrupting users who only want it for `.md` files.

**Solution:**

This PR introduces a new configuration setting: `markdown-preview-enhanced.disableAutoPreviewForUriSchemes`.

*   Allows users to specify URI scheme prefixes (like `vscode-notebook-cell`) to exclude from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature.
*   Skips auto-preview if the active document's scheme matches an exclusion.
*   Defaults to excluding `vscode-notebook-cell`, fixing the notebook issue while remaining customizable.

**Related Issue:**

Fixes #604