### PR TITLE
Fix preview selection in loop iteration

### DIFF
--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -532,7 +532,7 @@ export class PreviewProvider {
       }
       for (let i = 0; i < previews.length; i++) {
         try {
-          const preview = previews[0];
+          const preview = previews[i];
           const {
             html,
             tocHTML,


### PR DESCRIPTION
I've analyzed the VS Code Markdown Preview Enhanced extension and found the critical bug that prevents opening two markdown
  files at the same time.

  Root Cause

  The bug is in src/preview-provider.ts at line 535. In the updateMarkdown method, there's an array indexing error:

  for (let i = 0; i < previews.length; i++) {
    try {
      const preview = previews[0];  // BUG: Always uses index 0 instead of i

  Line 535 always uses previews[0] instead of previews[i], which means when multiple previews exist, the code only ever updates
  the first preview in the array, completely ignoring the others.

  How This Breaks Multiple File Previews

  1. In "Single Preview" mode: The default setting shows only one preview for all editors, so this bug doesn't manifest
  2. In "Multiple Previews" mode: When you have multiple markdown files open with their own previews:
    - The loop iterates through all previews (i = 0, 1, 2...)
    - But it always processes previews[0], causing it to:
        - Update the same preview multiple times
      - Ignore all other previews - Potentially cause race conditions or incorrect content display

  Fix Plan

⏺ Fix Plan

  The Problem

  In src/preview-provider.ts:535, the updateMarkdown method has a critical bug where it always uses previews[0] instead of
  previews[i] when iterating through multiple previews.

  Changes Required

  File: src/preview-provider.ts

  Line 535 - Change:
  const preview = previews[0];  // WRONG - always uses first preview

  To:
  const preview = previews[i];  // CORRECT - uses current iteration preview

  Impact

  This is a simple one-line fix that will:
  - ✅ Allow multiple markdown files to have their own independent previews
  - ✅ Fix the "Multiple Previews" mode functionality
  - ✅ Ensure each preview updates correctly when its corresponding markdown file changes
  - ✅ Eliminate race conditions caused by updating the same preview multiple times

  Testing Strategy

  After the fix:
  1. Set markdown-preview-enhanced.previewMode to "Multiple Previews"
  2. Open 2-3 markdown files
  3. Open preview for each file (Ctrl+K V)
  4. Edit each file and verify its preview updates correctly
  5. Verify no interference between different file previews

  Additional Notes

  - The bug only affects "Multiple Previews" mode
  - "Single Preview" mode (default) works fine because there's only one preview
  - The loop structure suggests the developer intended to iterate through all previews but made a typo using [0] instead of [i]