### PR TITLE
feat: add disableAutoPreviewForFilePatterns config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
           }
         },
         "markdown-preview-enhanced.disableAutoPreviewForFilePatterns": {
-          "markdownDescription": "A list of file name patterns (e.g., `*.note.md`) to exclude from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature. Files whose names match any of these patterns won't trigger the automatic preview. Supports `*` as a wildcard.",
+          "markdownDescription": "A list of file name patterns (e.g., `*.note.md`) to exclude from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature. Files whose names match any of these patterns won't trigger the automatic preview. Supports `*` as a wildcard. Matching is performed against the file's basename (not full path) and is case-insensitive.",
           "default": [],
           "type": "array",
           "items": {

--- a/package.json
+++ b/package.json
@@ -206,6 +206,14 @@
             "type": "string"
           }
         },
+        "markdown-preview-enhanced.disableAutoPreviewForFilePatterns": {
+          "markdownDescription": "A list of file name patterns (e.g., `*.note.md`) to exclude from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature. Files whose names match any of these patterns won't trigger the automatic preview. Supports `*` as a wildcard.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "markdown-preview-enhanced.previewColorScheme": {
           "type": "string",
           "enum": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,8 @@ type VSCodeMPEConfigKey =
   | 'qiniuDomain'
   | 'qiniuSecretKey'
   | 'scrollSync'
-  | 'disableAutoPreviewForUriSchemes';
+  | 'disableAutoPreviewForUriSchemes'
+  | 'disableAutoPreviewForFilePatterns';
 
 type ConfigKey = keyof NotebookConfig | VSCodeMPEConfigKey;
 

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -900,8 +900,9 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
         // Original check: Proceed only if it's considered a Markdown file
         if (isMarkdownFile(editor.document)) {
           // Check if the file matches any exclusion pattern
-          const exclusionPatterns =
-            getMPEConfig<string[]>('disableAutoPreviewForFilePatterns') ?? [];
+          const exclusionPatterns = (
+            getMPEConfig<string[]>('disableAutoPreviewForFilePatterns') ?? []
+          ).filter((p): p is string => typeof p === 'string');
           const fileName = path.basename(editor.document.fileName);
           const excluded = exclusionPatterns.some((pattern) => {
             // Simple wildcard matching: convert "*.note.md" to a regex

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -906,7 +906,7 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
           const excluded = exclusionPatterns.some((pattern) => {
             // Simple wildcard matching: convert "*.note.md" to a regex
             const escaped = pattern
-              .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+              .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
               .replace(/\*/g, '.*');
             return new RegExp(`^${escaped}$`, 'i').test(fileName);
           });

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -899,6 +899,18 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
 
         // Original check: Proceed only if it's considered a Markdown file
         if (isMarkdownFile(editor.document)) {
+          // Check if the file matches any exclusion pattern
+          const exclusionPatterns =
+            getMPEConfig<string[]>('disableAutoPreviewForFilePatterns') ?? [];
+          const fileName = path.basename(editor.document.fileName);
+          const excluded = exclusionPatterns.some((pattern) => {
+            // Simple wildcard matching: convert "*.note.md" to a regex
+            const escaped = pattern
+              .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+              .replace(/\*/g, '.*');
+            return new RegExp(`^${escaped}$`, 'i').test(fileName);
+          });
+
           const sourceUri = editor.document.uri;
           const automaticallyShowPreviewOfMarkdownBeingEdited = getMPEConfig<
             boolean
@@ -914,17 +926,20 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
               previewMode === PreviewMode.SinglePreview &&
               !previewProvider.previewHasTheSameSingleSourceUri(sourceUri)
             ) {
-              previewProvider.initPreview({
-                sourceUri,
-                document: editor.document,
-                cursorLine: getEditorActiveCursorLine(editor),
-                viewOptions: {
-                  viewColumn:
-                    previewProvider.getPreviews(sourceUri)?.at(0)?.viewColumn ??
-                    vscode.ViewColumn.One,
-                  preserveFocus: true,
-                },
-              });
+              // Skip auto-switching single preview to an excluded file
+              if (!excluded) {
+                previewProvider.initPreview({
+                  sourceUri,
+                  document: editor.document,
+                  cursorLine: getEditorActiveCursorLine(editor),
+                  viewOptions: {
+                    viewColumn:
+                      previewProvider.getPreviews(sourceUri)?.at(0)
+                        ?.viewColumn ?? vscode.ViewColumn.One,
+                    preserveFocus: true,
+                  },
+                });
+              }
             } else if (previewMode === PreviewMode.MultiplePreviews) {
               const previews = previewProvider.getPreviews(sourceUri);
               if (previews && previews.length > 0) {
@@ -933,7 +948,10 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
             }
             // NOTE: For PreviewMode.PreviewsOnly, we don't need to do anything.
           } else if (automaticallyShowPreviewOfMarkdownBeingEdited) {
-            openPreviewToTheSide(sourceUri);
+            // Skip auto-opening preview for an excluded file
+            if (!excluded) {
+              openPreviewToTheSide(sourceUri);
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Add a new configuration option `disableAutoPreviewForFilePatterns` that allows users to exclude specific markdown files from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature based on file name patterns
- Supports wildcard patterns (e.g., `*.note.md`) with `*` matching any characters; matching is performed against the file's basename and is case-insensitive
- Blocks both auto-open (no preview exists yet) and SinglePreview auto-switch (preview switches to a different file)
- Does not affect manually opened previews; existing previews in MultiplePreviews can still be revealed normally

## Motivation

When `automaticallyShowPreviewOfMarkdownBeingEdited` is enabled, **all** markdown files trigger automatic preview. However, some users maintain markdown files intended primarily for editing (e.g., `*.note.md` for note-taking) where automatic preview is unwanted. The existing `disableAutoPreviewForUriSchemes` cannot help here since these files share the same `file://` scheme.

## Usage

```json
{
  "markdown-preview-enhanced.automaticallyShowPreviewOfMarkdownBeingEdited": true,
  "markdown-preview-enhanced.disableAutoPreviewForFilePatterns": ["*.note.md"]
}
```

With this configuration:
- `README.md` — auto-preview opens as usual
- `todo.note.md` — opens in editor only, no auto-preview
- Manual preview (Ctrl+Shift+V) still works for all files

## Changes

- `package.json`: Added configuration schema for the new option
- `src/config.ts`: Added type for the new config key
- `src/extension-common.ts`: Added file name pattern matching to suppress auto-open and SinglePreview auto-switch for excluded files

No new dependencies introduced.

## Test plan

- [ ] Enable `automaticallyShowPreviewOfMarkdownBeingEdited`
- [ ] Set `disableAutoPreviewForFilePatterns` to `["*.note.md"]`
- [ ] Open a `*.note.md` file — verify no auto-preview
- [ ] Open a regular `*.md` file — verify auto-preview still works
- [ ] Manually trigger preview on `*.note.md` — verify it works
- [ ] In SinglePreview mode, switch from `*.md` to `*.note.md` — verify preview does not auto-switch
- [ ] In MultiplePreviews mode with a manually opened preview for `*.note.md` — verify reveal still works