### PR TITLE
Add D2 diagram rendering support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,15 @@ jobs:
     name: "Test"
     runs-on: ubuntu-latest
     steps:
-      - name: 'Check out code'
+      - name: "Check out code"
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: 'Install nodejs 20'
+      - name: "Install nodejs 20"
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
-      - name: 'Build and test'
+          node-version: "20"
+      - name: "Build and test"
         run: |
           corepack enable
           yarn global add @vscode/vsce
@@ -48,3 +48,9 @@ jobs:
           registryUrl: https://open-vsx.org
           extensionFile: ${{ steps.dry_run_vsix.outputs.vsixPath }}
           yarn: true
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension
+          path: ${{ steps.dry_run_vsix.outputs.vsixPath }}
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support rendering [D2](https://d2lang.com) diagrams via the `d2` CLI. D2 fenced code blocks are rendered as SVG diagrams in the preview. If the `d2` executable is not installed, blocks are silently rendered as plain code blocks.
+  - New settings: `markdown-preview-enhanced.d2Path`, `d2Layout`, `d2Theme`, `d2Sketch`
+  - Per-block overrides supported in the fence info string: `` ```d2 layout=elk theme=200 sketch ``
+
 ## [0.8.22] - 2026-03-22
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.20](https://github.com/shd101wyy/crossnote/releases/tag/0.9.20).

--- a/package.json
+++ b/package.json
@@ -604,6 +604,32 @@
           "default": "",
           "type": "string"
         },
+        "markdown-preview-enhanced.d2Path": {
+          "description": "Path to the D2 executable. Defaults to `d2` (i.e. found on PATH). Not supported in the web extension.",
+          "default": "d2",
+          "type": "string",
+          "scope": "machine"
+        },
+        "markdown-preview-enhanced.d2Layout": {
+          "description": "Default D2 layout engine for rendering d2 diagrams.",
+          "default": "dagre",
+          "type": "string",
+          "enum": [
+            "dagre",
+            "elk",
+            "tala"
+          ]
+        },
+        "markdown-preview-enhanced.d2Theme": {
+          "description": "Default D2 theme ID for rendering d2 diagrams. See https://d2lang.com/tour/themes for available theme IDs.",
+          "default": 0,
+          "type": "number"
+        },
+        "markdown-preview-enhanced.d2Sketch": {
+          "description": "Render D2 diagrams in sketch (hand-drawn) style.",
+          "default": false,
+          "type": "boolean"
+        },
         "markdown-preview-enhanced.markdownFileExtensions": {
           "description": "Markdown file extensions. This is used to determine whether to show the preview button in the markdown file context menu.",
           "default": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,11 @@ type VSCodeMPEConfigKey =
   | 'qiniuDomain'
   | 'qiniuSecretKey'
   | 'scrollSync'
-  | 'disableAutoPreviewForUriSchemes';
+  | 'disableAutoPreviewForUriSchemes'
+  | 'd2Path'
+  | 'd2Layout'
+  | 'd2Theme'
+  | 'd2Sketch';
 
 type ConfigKey = keyof NotebookConfig | VSCodeMPEConfigKey;
 
@@ -95,6 +99,11 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
   public readonly enablePreviewZenMode: boolean;
   public readonly wikiLinkTargetFileExtension: string;
   public readonly wikiLinkTargetFileNameChangeCase: WikiLinkTargetFileNameChangeCase;
+  // D2 diagram settings
+  public readonly d2Path: string;
+  public readonly d2Layout: string;
+  public readonly d2Theme: number;
+  public readonly d2Sketch: boolean;
   // Don't set values for these properties in constructor:
   public readonly includeInHeader: string;
   public readonly globalCss: string;
@@ -269,6 +278,10 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
       getMPEConfig<WikiLinkTargetFileNameChangeCase>(
         'wikiLinkTargetFileNameChangeCase',
       ) ?? defaultConfig.wikiLinkTargetFileNameChangeCase;
+    this.d2Path = getMPEConfig<string>('d2Path') ?? 'd2';
+    this.d2Layout = getMPEConfig<string>('d2Layout') ?? 'dagre';
+    this.d2Theme = getMPEConfig<number>('d2Theme') ?? 0;
+    this.d2Sketch = getMPEConfig<boolean>('d2Sketch') ?? false;
   }
 
   public isEqualTo(otherConfig: MarkdownPreviewEnhancedConfig) {

--- a/src/notebooks-manager.ts
+++ b/src/notebooks-manager.ts
@@ -1,8 +1,10 @@
 import {
   Notebook,
   NotebookConfig,
+  ParserConfig,
   PreviewMode,
   PreviewTheme,
+  getDefaultParserConfig,
   loadConfigsInDirectory,
 } from 'crossnote';
 import * as vscode from 'vscode';
@@ -25,6 +27,8 @@ class NotebooksManager {
   public systemColorScheme: 'light' | 'dark' = 'light';
   private fileWatcher: FileWatcher;
   private currentMPEConfig: MarkdownPreviewEnhancedConfig = MarkdownPreviewEnhancedConfig.getCurrentConfig();
+  /** Cache of D2 renders: key = hash of (code + attrs), value = rendered SVG/error HTML */
+  private d2Cache: Map<string, string> = new Map();
 
   constructor(private context: vscode.ExtensionContext) {
     this.fileWatcher = new FileWatcher(this.context, this);
@@ -120,6 +124,20 @@ class NotebooksManager {
       globalCss:
         (globalConfig.globalCss ?? '') + (workspaceConfig.globalCss ?? ''),
       previewTheme,
+      ...(!isVSCodeWebExtension() && {
+        parserConfig: createD2ParserConfig(
+          (workspaceConfig.parserConfig ??
+            globalConfig.parserConfig ??
+            getDefaultParserConfig()) as ParserConfig,
+          {
+            d2Path: vscodeMPEConfig.d2Path || 'd2',
+            d2Layout: vscodeMPEConfig.d2Layout || 'dagre',
+            d2Theme: vscodeMPEConfig.d2Theme ?? 0,
+            d2Sketch: vscodeMPEConfig.d2Sketch ?? false,
+          },
+          this.d2Cache,
+        ),
+      }),
     };
   }
 
@@ -183,6 +201,16 @@ class NotebooksManager {
       previewProviders.forEach((provider) => {
         provider.closeAllPreviews(this.currentMPEConfig.previewMode);
       });
+    }
+
+    // Clear D2 cache when config changes (e.g. d2Path/d2Layout/d2Theme/d2Sketch may have changed)
+    if (
+      this.currentMPEConfig.d2Path !== newMPEConfig.d2Path ||
+      this.currentMPEConfig.d2Layout !== newMPEConfig.d2Layout ||
+      this.currentMPEConfig.d2Theme !== newMPEConfig.d2Theme ||
+      this.currentMPEConfig.d2Sketch !== newMPEConfig.d2Sketch
+    ) {
+      this.d2Cache.clear();
     }
 
     // Update all notebooks config
@@ -292,3 +320,219 @@ class NotebooksManager {
 }
 
 export default NotebooksManager;
+
+// ---------------------------------------------------------------------------
+// D2 diagram rendering helpers
+// ---------------------------------------------------------------------------
+
+interface D2RenderOptions {
+  d2Path: string;
+  d2Layout: string;
+  d2Theme: number;
+  d2Sketch: boolean;
+}
+
+/**
+ * Render a single D2 diagram source string to SVG (or an error HTML block).
+ * Writes temp files, shells out to the `d2` CLI, then cleans up.
+ */
+/**
+ * Returned when d2 is not installed — signals the caller to leave the
+ * original code block in place rather than showing an error.
+ */
+const D2_NOT_FOUND = Symbol('D2_NOT_FOUND');
+
+async function renderD2ToSvg(
+  code: string,
+  opts: D2RenderOptions,
+): Promise<string | typeof D2_NOT_FOUND> {
+  // critical path (they are still polyfilled, but never actually called
+  // because we guard with isVSCodeWebExtension() before calling this).
+  const os = await import('os');
+  const fs = await import('fs');
+  const path = await import('path');
+  const crypto = await import('crypto');
+  const { execFile } = await import('child_process');
+
+  const id = crypto.randomBytes(8).toString('hex');
+  const tmpIn = path.join(os.tmpdir(), `d2-${id}.d2`);
+  const tmpOut = path.join(os.tmpdir(), `d2-${id}.svg`);
+
+  try {
+    await fs.promises.writeFile(tmpIn, code, 'utf8');
+    await new Promise<void>((resolve, reject) => {
+      const args = [
+        `--theme=${opts.d2Theme}`,
+        `--layout=${opts.d2Layout}`,
+        ...(opts.d2Sketch ? ['--sketch'] : []),
+        tmpIn,
+        tmpOut,
+      ];
+      execFile(
+        opts.d2Path,
+        args,
+        { windowsHide: true, shell: true },
+        (err, _stdout, stderr) => {
+          if (err) {
+            // Attach the original error code so callers can detect ENOENT
+            const wrapped = new Error(stderr || err.message) as Error & { code?: string };
+            wrapped.code = (err as NodeJS.ErrnoException).code;
+            reject(wrapped);
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
+    return await fs.promises.readFile(tmpOut, 'utf8');
+  } catch (err: any) {
+    // d2 binary not found — caller will fall back to original code block.
+    // With shell:true on Windows, cmd.exe exits with code 1 and prints
+    // "is not recognized..." instead of an ENOENT from the OS.
+    const msg: string = err?.message ?? String(err);
+    const isNotFound =
+      err?.code === 'ENOENT' ||
+      /not recognized as an internal or external command/i.test(msg) ||
+      /not found/i.test(msg) ||
+      /cannot find/i.test(msg) ||
+      /No such file or directory/i.test(msg);
+    if (isNotFound) return D2_NOT_FOUND;
+    const escaped = msg.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `<pre class="language-text"><code>D2 error: ${escaped}</code></pre>`;
+  } finally {
+    try {
+      const fs2 = await import('fs');
+      fs2.promises.unlink(tmpIn).catch(() => undefined);
+      fs2.promises.unlink(tmpOut).catch(() => undefined);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Decode HTML entities in a code element's text content.
+ */
+function htmlDecodeCode(encoded: string): string {
+  return encoded
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/<\/?code[^>]*>/g, '') // strip <code> wrapper added by cheerio
+    .trim();
+}
+
+/**
+ * Parse per-block D2 attributes from the fence info string after "d2".
+ * Accepted syntax (space-separated):  layout=elk  theme=200  sketch  no-sketch
+ */
+function parseD2BlockAttrs(
+  attrs: string,
+  defaults: D2RenderOptions,
+): D2RenderOptions {
+  let d2Layout = defaults.d2Layout;
+  let d2Theme = defaults.d2Theme;
+  let d2Sketch = defaults.d2Sketch;
+  for (const part of attrs.split(/\s+/)) {
+    if (part.startsWith('layout=')) {
+      d2Layout = part.slice('layout='.length) || d2Layout;
+    } else if (part.startsWith('theme=')) {
+      const n = parseInt(part.slice('theme='.length), 10);
+      if (!Number.isNaN(n)) d2Theme = n;
+    } else if (part === 'sketch') {
+      d2Sketch = true;
+    } else if (part === 'no-sketch') {
+      d2Sketch = false;
+    }
+  }
+  return { d2Path: defaults.d2Path, d2Layout, d2Theme, d2Sketch };
+}
+
+/**
+ * Find all <pre data-role="codeBlock" data-info="d2...">…</pre> blocks in
+ * the rendered HTML, render each with the d2 CLI, replace with SVG div.
+ *
+ * crossnote's markdown-it renderer emits code fences as:
+ *   <pre data-role="codeBlock" data-info="d2 {attrs}" ...>HTML-encoded code</pre>
+ * (no nested <code> element).
+ *
+ * Per-block overrides are parsed from the data-info attribute which contains
+ * the raw fence info string, e.g. "d2 layout=elk theme=200 sketch".
+ */
+async function renderD2InHtml(
+  html: string,
+  opts: D2RenderOptions,
+  cache: Map<string, string>,
+): Promise<string> {
+  // Match <pre ... data-info="d2" ...> or data-info="d2 ..."
+  const re =
+    /<pre\b([^>]*\bdata-info="(d2(?:\s[^"]*)?)"[^>]*)>([\s\S]*?)<\/pre>/g;
+
+  const matches: Array<{
+    match: string;
+    dataInfo: string;
+    rawCode: string;
+    index: number;
+  }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    matches.push({
+      match: m[0],
+      dataInfo: m[2],
+      rawCode: htmlDecodeCode(m[3]),
+      index: m.index,
+    });
+  }
+
+  if (matches.length === 0) return html;
+
+  // Render all diagrams in parallel.
+  const rendered = await Promise.all(
+    matches.map(async ({ dataInfo, rawCode }) => {
+      // Parse per-block overrides from the fence info string after "d2".
+      const attrs = dataInfo.slice(2).trim(); // remove leading "d2"
+      const renderOpts = parseD2BlockAttrs(attrs, opts);
+      const cacheKey = `${renderOpts.d2Layout}:${renderOpts.d2Theme}:${renderOpts.d2Sketch}:${rawCode}`;
+      if (cache.has(cacheKey)) return cache.get(cacheKey)!;
+      const svg = await renderD2ToSvg(rawCode, renderOpts);
+      if (svg !== D2_NOT_FOUND) cache.set(cacheKey, svg);
+      return svg;
+    }),
+  );
+
+  // Replace from back to front to preserve earlier indices.
+  let result = html;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const { match, index } = matches[i];
+    // D2_NOT_FOUND means d2 is not installed — leave the original block
+    if (rendered[i] === D2_NOT_FOUND) continue;
+    const svg = rendered[i] as string;
+    result =
+      result.slice(0, index) +
+      `<div class="d2-diagram">${svg}</div>` +
+      result.slice(index + match.length);
+  }
+  return result;
+}
+
+/**
+ * Wrap an existing ParserConfig to add D2 rendering.
+ * All work is done in onDidParseMarkdown so we operate on the final HTML
+ * (crossnote's transformMarkdown strips HTML comments, making any
+ * onWillParseMarkdown placeholder approach impossible).
+ */
+function createD2ParserConfig(
+  existing: ParserConfig,
+  opts: D2RenderOptions,
+  cache: Map<string, string>,
+): ParserConfig {
+  return {
+    onWillParseMarkdown: existing.onWillParseMarkdown,
+    onDidParseMarkdown: async (html: string) => {
+      const base = await existing.onDidParseMarkdown(html);
+      return renderD2InHtml(base, opts, cache);
+    },
+  };
+}


### PR DESCRIPTION
## Add D2 diagram rendering support

Adds native rendering of [D2](https://d2lang.com) diagrams in the preview by shelling out to the `d2` CLI. Consistent with how other external-binary diagram tools (PlantUML, Kroki) are handled.

### What's new

- ` ```d2 ` fenced code blocks are rendered as inline SVG in the preview.
- If the `d2` binary is not installed, the block silently falls back to a plain code block — no error shown.
- Four new settings:
  - `markdown-preview-enhanced.d2Path` — path to the `d2` executable (default: `d2` on PATH)
  - `markdown-preview-enhanced.d2Layout` — layout engine: `dagre` (default), `elk`, `tala`
  - `markdown-preview-enhanced.d2Theme` — theme ID (default: `0`, see [D2 themes](https://d2lang.com/tour/themes))
  - `markdown-preview-enhanced.d2Sketch` — enable hand-drawn sketch style (default: `false`)
- Per-block overrides via the fence info string, e.g. ` ```d2 layout=elk theme=200 sketch `
- Render results are cached per content+options hash; cache is invalidated on config change.
- Not active in the web extension (`vscode.dev`).

### CI improvement

Updated `.github/workflows/test.yml` to upload the packaged `.vsix` as a downloadable build artifact on every push/PR, making it easy to install and test without a local build.