### PR TITLE
Add D2 rendering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support rendering [D2](https://d2lang.com) diagrams via the `d2` CLI. D2 fenced code blocks are rendered as SVG diagrams in the preview. If the `d2` executable is not installed, blocks are silently rendered as plain code blocks.
+  - New settings: `markdown-preview-enhanced.d2Path`, `d2Layout`, `d2Theme`, `d2Sketch`
+  - Per-block overrides supported in the fence info string: `` ```d2 layout=elk theme=200 sketch ``
+
 ## [0.8.22] - 2026-03-22
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.20](https://github.com/shd101wyy/crossnote/releases/tag/0.9.20).

--- a/package.json
+++ b/package.json
@@ -612,6 +612,76 @@
           "default": "",
           "type": "string"
         },
+        "markdown-preview-enhanced.d2Path": {
+          "description": "Path to the D2 executable. Defaults to `d2` (i.e. found on PATH). Not supported in the web extension.",
+          "default": "d2",
+          "type": "string",
+          "scope": "machine"
+        },
+        "markdown-preview-enhanced.d2Layout": {
+          "description": "Default D2 layout engine for rendering d2 diagrams.",
+          "default": "dagre",
+          "type": "string",
+          "enum": [
+            "dagre",
+            "elk",
+            "tala"
+          ]
+        },
+        "markdown-preview-enhanced.d2Theme": {
+          "description": "Default D2 theme for rendering d2 diagrams.",
+          "default": 0,
+          "type": "number",
+          "enum": [
+            0,
+            1,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            100,
+            101,
+            102,
+            103,
+            104,
+            105,
+            200,
+            201,
+            300,
+            301,
+            302,
+            303
+          ],
+          "enumItemLabels": [
+            "Neutral Default",
+            "Neutral Grey",
+            "Flagship Terrastruct",
+            "Cool Classics",
+            "Mixed Berry Blue",
+            "Grape Soda",
+            "Aubergine",
+            "Colorblind Clear",
+            "Vanilla Nitro Cola",
+            "Orange Creamsicle",
+            "Shirley Temple",
+            "Earth Tones",
+            "Everglade Green",
+            "Buttered Toast",
+            "Dark Mauve",
+            "Dark Flagship Terrastruct",
+            "Terminal",
+            "Terminal Grayscale",
+            "Origami",
+            "C4"
+          ]
+        },
+        "markdown-preview-enhanced.d2Sketch": {
+          "description": "Render D2 diagrams in sketch (hand-drawn) style.",
+          "default": false,
+          "type": "boolean"
+        },
         "markdown-preview-enhanced.markdownFileExtensions": {
           "description": "Markdown file extensions. This is used to determine whether to show the preview button in the markdown file context menu.",
           "default": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,11 @@ type VSCodeMPEConfigKey =
   | 'qiniuSecretKey'
   | 'scrollSync'
   | 'disableAutoPreviewForUriSchemes'
-  | 'disableAutoPreviewForFilePatterns';
+  | 'disableAutoPreviewForFilePatterns'
+  | 'd2Path'
+  | 'd2Layout'
+  | 'd2Theme'
+  | 'd2Sketch';
 
 type ConfigKey = keyof NotebookConfig | VSCodeMPEConfigKey;
 
@@ -96,6 +100,11 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
   public readonly enablePreviewZenMode: boolean;
   public readonly wikiLinkTargetFileExtension: string;
   public readonly wikiLinkTargetFileNameChangeCase: WikiLinkTargetFileNameChangeCase;
+  // D2 diagram settings
+  public readonly d2Path: string;
+  public readonly d2Layout: string;
+  public readonly d2Theme: number;
+  public readonly d2Sketch: boolean;
   // Don't set values for these properties in constructor:
   public readonly includeInHeader: string;
   public readonly globalCss: string;
@@ -270,6 +279,10 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
       getMPEConfig<WikiLinkTargetFileNameChangeCase>(
         'wikiLinkTargetFileNameChangeCase',
       ) ?? defaultConfig.wikiLinkTargetFileNameChangeCase;
+    this.d2Path = getMPEConfig<string>('d2Path') ?? 'd2';
+    this.d2Layout = getMPEConfig<string>('d2Layout') ?? 'dagre';
+    this.d2Theme = getMPEConfig<number>('d2Theme') ?? 0;
+    this.d2Sketch = getMPEConfig<boolean>('d2Sketch') ?? false;
   }
 
   public isEqualTo(otherConfig: MarkdownPreviewEnhancedConfig) {


### PR DESCRIPTION
## Add D2 diagram rendering support

Adds support for rendering [D2](https://d2lang.com) diagrams in the preview via the `d2` CLI.

### Usage

~~~markdown
```d2
shape: sequence_diagram
alice -> bob: What does it mean?
bob -> alice: 42
```
~~~

Per-block options can be set in the fence info string:

~~~markdown
```d2 layout=elk theme=200 sketch
...
```
~~~

### New settings

| Setting                              | Default               | Description                               |
| ------------------------------------ | --------------------- | ----------------------------------------- |
| `markdown-preview-enhanced.d2Path`   | `d2`                  | Path to the `d2` executable               |
| `markdown-preview-enhanced.d2Layout` | `dagre`               | Layout engine (`dagre`, `elk`, `tala`)    |
| `markdown-preview-enhanced.d2Theme`  | `0` (Neutral Default) | Theme — dropdown with all named D2 themes |
| `markdown-preview-enhanced.d2Sketch` | `false`               | Hand-drawn sketch style                   |

Per-block settings override the global ones. Use `sketch=false` to disable sketch for a specific block when the global setting is on.

### Notes

- Requires the `d2` CLI to be installed and on PATH (or configured via `d2Path`)
- If `d2` is not installed, blocks silently fall back to plain code blocks — no errors
- Not supported in the web extension

