### PR TITLE
Added preview scroll option and restyled menu, now looking more native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
-- Add Ctrl+mouse-wheel zoom in the preview pane — zoom in/out with Ctrl+scroll (or Cmd+scroll on macOS). Fixed-position UI elements (buttons, menus) stay at their original size at any zoom level. Requires the VS Code setting `editor.mouseWheelZoom` to be enabled (`Settings > Editor: Mouse Wheel Zoom`).
+- Add Ctrl+mouse-wheel zoom in the preview pane — zoom in/out with Ctrl+scroll (or Cmd+scroll on macOS). Requires the VS Code setting `editor.mouseWheelZoom` to be enabled (`Settings > Editor: Mouse Wheel Zoom`).
 
 ### Improvements
 
@@ -327,7 +327,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.4](h
 
 ### New features
 
-- Updated [fontawesome](https://fontawesome.com/) from version 4.7 to version 6.4.2 (Free).  
+- Updated [fontawesome](https://fontawesome.com/) from version 4.7 to version 6.4.2 (Free).
   A list of available icons can be found at: https://kapeli.com/cheat_sheets/Font_Awesome.docset/Contents/Resources/Documents/index
 - Updated WaveDrom to the latest version 3.3.0.
 
@@ -467,7 +467,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.20](
 
 ### New features
 
-- Supported prefix in front of Kroki diagram types https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1785.  
+- Supported prefix in front of Kroki diagram types https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1785.
   So now all diagrams below will get rendered using Kroki:
 
   ````markdown
@@ -501,18 +501,18 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.19](
 
 ### Changes
 
-- Deprecated the `processWikiLink` in `parser.js`. Now `crossnote` handles how we process the wiki link.  
+- Deprecated the `processWikiLink` in `parser.js`. Now `crossnote` handles how we process the wiki link.
   We also added two more options:
   - `wikiLinkTargetFileExtension`: The file extension of the target file. Default is `md`. For example:
     - `[[test]]` will be transformed to `[test](test.md)`
     - `[[test.md]]` will be transformed to `[test](test.md)`
     - `[[test.pdf]]` will be transformed to `[test](test.pdf)` because it has a file extension.
-  - `wikiLinkTargetFileNameChangeCase`: How we transform the file name. Default is `none` so we won't change the file name.  
+  - `wikiLinkTargetFileNameChangeCase`: How we transform the file name. Default is `none` so we won't change the file name.
     A list of available options can be found at: https://shd101wyy.github.io/crossnote/types/WikiLinkTargetFileNameChangeCase.html
 
 ### Bug fixes
 
-- Reverted the markdown transformer and deleted the logic of inserting anchor elements as it's causing a lot of problems.  
+- Reverted the markdown transformer and deleted the logic of inserting anchor elements as it's causing a lot of problems.
   The in-preview editor is not working as expected. So we now hide its highlight lines and elements feature if the markdown file failed to generate the correct source map.
 - Fixed the bug that global custom CSS is not working.
 
@@ -522,16 +522,16 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.17](
 
 ### New features
 
-- 📝 Supported in-preview editor that allows you to edit the markdown file directly in the preview 🎉.  
-  This feature is currently in beta.  
+- 📝 Supported in-preview editor that allows you to edit the markdown file directly in the preview 🎉.
+  This feature is currently in beta.
   When the editor is open, you can press `ctrl+s` or `cmd+s` to save the markdown file. You can also press `esc` to close the editor.
-- Deprecated the VS Code setting `markdown-preview-enhanced.singlePreview`.  
+- Deprecated the VS Code setting `markdown-preview-enhanced.singlePreview`.
   Now replaced by `markdown-preview-enhanced.previewMode`:
-  - **Single Preview** (_default_)  
+  - **Single Preview** (_default_)
     Only one preview will be shown for all editors.
-  - **Multiple Previews**  
+  - **Multiple Previews**
     Multiple previews will be shown. Each editor has its own preview.
-  - **Previews Only** 🆕  
+  - **Previews Only** 🆕
     No editor will be shown. Only previews will be shown. You can use the in-preview editor to edit the markdown.
 
     🔔 Please note that enable this option will automatically modify the `workbench.editorAssociations` setting to make sure the markdown files are opened in the custom editor for preview.
@@ -544,7 +544,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.17](
   ![](path/to/image.png){width=100 height=100}
   ```
 
-- Improved the markdown transformer to better insert anchors for scroll sync and highlight lines and elements.  
+- Improved the markdown transformer to better insert anchors for scroll sync and highlight lines and elements.
   Added more tests for the markdown transformer to make sure it works as expected.
 - Added the reading time estimation in the preview footer ⏲️.
 - Added `Edit Markdown` menu item to the context menu of the preview, which offers two options:
@@ -642,7 +642,7 @@ Fixed reading file as base64
 ### New features 🆕
 
 1. Complete rewrite of the webview, and improved the UI. 🌐💅
-2. Backlinks supported in the preview. Clicking the bottom right link icon will display the backlinks. This feature is currently in beta and might not be stable yet.  
+2. Backlinks supported in the preview. Clicking the bottom right link icon will display the backlinks. This feature is currently in beta and might not be stable yet.
    If you want the backlinks to be always on in the preview, you can enable the setting:
 
    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New features
+
+- Add Ctrl+mouse-wheel zoom in the preview pane — zoom in/out with Ctrl+scroll (or Cmd+scroll on macOS). Fixed-position UI elements (buttons, menus) stay at their original size at any zoom level. Requires the VS Code setting `editor.mouseWheelZoom` to be enabled (`Settings > Editor: Mouse Wheel Zoom`).
+
+### Improvements
+
+- Restyle context menu to match VS Code — the right-click menu now uses the VS Code theme colors, font family, and font size instead of the preview theme, so it looks native at any zoom level or theme setting.
+- Make context menu more compact — smaller minimum width, tighter item padding, and reduced separator margins for a cleaner, VS Code-like appearance.
+
 ## [0.8.24] - 2026-04-21
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.22](https://github.com/shd101wyy/crossnote/releases/tag/0.9.22).

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "shd101wyy",
     "kachkaev",
     "gabyx",
-    "mavaddat"
+    "mavaddat",
+    "nielsvdc"
   ],
   "publisher": "shd101wyy",
   "main": "./out/native/extension.js",

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -588,7 +588,7 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
         ) {
           /*
           // NOTE: This doesn't work for the `line`
-          // so we use the `initPreview` instead.  
+          // so we use the `initPreview` instead.
           const options: vscode.TextDocumentShowOptions = {
             selection: new vscode.Selection(line, 0, line, 0),
             viewColumn: vscode.ViewColumn.Active,

--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -426,6 +426,18 @@ export class PreviewProvider {
         // register previewPanel message events.
         previewPanel.webview.onDidReceiveMessage(
           (message) => {
+            // Relay zoom commands back to
+            // the webview so crossnote's React handler stays in sync.
+            // Part of the Ctrl+wheel zoom customization.
+            if (
+              message.command === 'zommIn' ||
+              message.command === 'zoomOut' ||
+              message.command === 'resetZoom'
+            ) {
+              previewPanel.webview.postMessage(message);
+              return;
+            }
+
             // console.log('@ receiveMessage: ', message, previewPanel);
             vscode.commands.executeCommand(
               `_crossnote.${message.command}`,
@@ -507,7 +519,114 @@ export class PreviewProvider {
         return;
       }
 
-      previewPanel.webview.html = html;
+      // ──────────────────────────────────────────────────────────────
+      // VS Code-style context menu customization:
+      // Reskins the react-contexify right-click menu to look and feel
+      // like a native VS Code menu:
+      //  - Compact sizing (smaller min-width, tighter padding/margins)
+      //  - VS Code theme colors (background, foreground, selection,
+      //    separator, border) via --vscode-menu-* CSS variables
+      //  - VS Code UI font family and size
+      // Works by overriding contexify CSS custom properties on :root
+      // via inline styles, which beat the <style> tags that
+      // react-contexify injects at runtime.
+      // ──────────────────────────────────────────────────────────────
+      const compactMenuScript = `<script>
+(function() {
+  var root = document.documentElement;
+  root.style.setProperty('--contexify-menu-minWidth', '160px');
+  root.style.setProperty('--contexify-itemContent-padding', '4px 8px');
+  root.style.setProperty('--contexify-separator-margin', '3px');
+
+  // Theme: map VS Code menu colors to contexify variables so the
+  // context menu always matches the VS Code theme, not the preview theme.
+  root.style.setProperty('--contexify-menu-bgColor', 'var(--vscode-menu-background)');
+  root.style.setProperty('--contexify-separator-color', 'var(--vscode-menu-separatorBackground)');
+  root.style.setProperty('--contexify-item-color', 'var(--vscode-menu-foreground)');
+  root.style.setProperty('--contexify-activeItem-color', 'var(--vscode-menu-selectionForeground)');
+  root.style.setProperty('--contexify-activeItem-bgColor', 'var(--vscode-menu-selectionBackground)');
+  root.style.setProperty('--contexify-rightSlot-color', 'var(--vscode-menu-foreground)');
+  root.style.setProperty('--contexify-arrow-color', 'var(--vscode-menu-foreground)');
+
+  // Font: match VS Code's UI font size and family.
+  var style = document.createElement('style');
+  style.textContent = '.contexify { font-size: var(--vscode-font-size); font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif; border: 1px solid var(--vscode-menu-border, transparent); border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.16); }';
+  document.head.appendChild(style);
+})();
+</script>`;
+
+      // ──────────────────────────────────────────────────────────────
+      // Ctrl+wheel zoom customization:
+      // Adds Ctrl+mouse-wheel zoom to the preview webview using the
+      // CSS `zoom` property (doesn't break position:fixed or cause
+      // scrollbars). Fixed UI elements (.fixed) and context menus
+      // (.contexify, top-level only) get a counter-zoom so they stay
+      // at their original size; nested submenus are skipped to avoid
+      // double counter-zooming. A MutationObserver reapplies the
+      // counter-zoom when new elements are added to the DOM.
+      // NOTE: crossnote checks for "zommIn" (typo in upstream).
+      // ──────────────────────────────────────────────────────────────
+      const wheelZoomScript = `<script>
+(function() {
+  var _origAcquire = window.acquireVsCodeApi;
+  var _cachedApi;
+  if (_origAcquire) {
+    window.acquireVsCodeApi = function() {
+      if (!_cachedApi) _cachedApi = _origAcquire();
+      return _cachedApi;
+    };
+  }
+
+  var zoomLevel = 1;
+
+  function applyCounterZoom() {
+    var counterZoom = 1 / zoomLevel;
+    var els = document.querySelectorAll('.fixed, .contexify');
+    for (var i = 0; i < els.length; i++) {
+      // Skip nested .contexify (submenus inside a parent menu) —
+      // they inherit the parent's counter-zoom automatically.
+      if (els[i].classList.contains('contexify') &&
+          els[i].parentElement &&
+          els[i].parentElement.closest('.contexify')) {
+        els[i].style.zoom = '';
+        continue;
+      }
+      els[i].style.zoom = counterZoom;
+    }
+  }
+
+  new MutationObserver(function() {
+    if (zoomLevel !== 1) applyCounterZoom();
+  }).observe(document.body, { childList: true, subtree: true });
+
+  document.addEventListener('wheel', function(e) {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.deltaY < 0) {
+        zoomLevel = Math.min(zoomLevel * 1.1, 5);
+      } else {
+        zoomLevel = Math.max(zoomLevel / 1.1, 0.2);
+      }
+      document.body.style.zoom = zoomLevel;
+      applyCounterZoom();
+      try {
+        var api = window.acquireVsCodeApi ? window.acquireVsCodeApi() : null;
+        if (api) {
+          var cmd = e.deltaY < 0 ? 'zommIn' : 'zoomOut';
+          api.postMessage({ command: cmd, args: [] });
+        }
+      } catch (_) {}
+    }
+  }, { passive: false, capture: true });
+})();
+</script>`;
+
+      // Inject customizations into the webview HTML.
+      previewPanel.webview.html = html.replace(
+        '</body>',
+        compactMenuScript + wheelZoomScript + '</body>',
+      );
     } catch (error) {
       vscode.window.showErrorMessage(String(error));
       console.error(error);


### PR DESCRIPTION
### New feature

- Add Ctrl+mouse-wheel zoom in the preview pane — zoom in/out with Ctrl+scroll (or Cmd+scroll on macOS). Requires the VS Code setting `editor.mouseWheelZoom` to be enabled (`Settings > Editor: Mouse Wheel Zoom`).

### Improvements

- Restyle context menu to match VS Code — the right-click menu now uses the VS Code theme colors, font family, and font size instead of the preview theme, so it looks native at any zoom level or theme setting.
- Make context menu more compact — smaller minimum width, tighter item padding, and reduced separator margins for a cleaner, VS Code-like appearance.