### PR TITLE
Possible bugfix for #2224

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug fixes
+
+- Fix crash when using Remote SSH with a Windows client and Linux host — a Windows-style URI was passed to the Linux remote, producing an invalid notebook path that caused continuous `"notebookPath is not valid"` errors in the Extension Host log ([#2224](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2224))
+
 ## [0.8.24] - 2026-04-21
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.22](https://github.com/shd101wyy/crossnote/releases/tag/0.9.22).

--- a/src/notebooks-manager.ts
+++ b/src/notebooks-manager.ts
@@ -27,6 +27,8 @@ class NotebooksManager {
   private currentMPEConfig: MarkdownPreviewEnhancedConfig =
     MarkdownPreviewEnhancedConfig.getCurrentConfig();
 
+  private failedNotebookPaths: Set<string> = new Set();
+
   constructor(private context: vscode.ExtensionContext) {
     this.fileWatcher = new FileWatcher(this.context, this);
   }
@@ -44,14 +46,27 @@ class NotebooksManager {
       }
     }
     // If not, create a new Notebook instance and push it to this.notebooks
-    const notebook = await Notebook.init({
-      notebookPath: workspaceFolderUri.toString(),
-      fs: wrapVSCodeFSAsApi(
-        workspaceFolderUri.scheme,
-        workspaceFolderUri.authority,
-      ),
-      config: {},
-    });
+    const notebookPathStr = workspaceFolderUri.toString();
+    if (this.failedNotebookPaths.has(notebookPathStr)) {
+      throw new Error(
+        `Notebook initialization previously failed for: ${notebookPathStr}`,
+      );
+    }
+
+    let notebook: Notebook;
+    try {
+      notebook = await Notebook.init({
+        notebookPath: notebookPathStr,
+        fs: wrapVSCodeFSAsApi(
+          workspaceFolderUri.scheme,
+          workspaceFolderUri.authority,
+        ),
+        config: {},
+      });
+    } catch (error) {
+      this.failedNotebookPaths.add(notebookPathStr);
+      throw error;
+    }
     this.notebooks.push(notebook);
     notebook.updateConfig(await this.loadNotebookConfig(uri));
     return notebook;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,16 @@ export function getWorkspaceFolderUri(uri: vscode.Uri) {
     }
   }
 
+  // Detect cross-platform URI mismatch (e.g., Windows-style URI on a Linux
+  // remote connected via Remote SSH). The fsPath will contain a Windows drive
+  // letter that is not a valid local path, so fall back to the first workspace
+  // folder instead of producing an invalid URI.
+  if (process.platform !== 'win32' && /^[a-zA-Z]:/.test(uri.fsPath)) {
+    if (workspaces && workspaces.length > 0) {
+      return workspaces[0].uri;
+    }
+  }
+
   // Return the folder of uri
   return vscode.Uri.file(path.dirname(uri.fsPath));
 }

--- a/test/markdown/README.md
+++ b/test/markdown/README.md
@@ -6,4 +6,5 @@
 - [[file-imports]]
 - [[interactive-diagrams]]
 - [math](./math.md)
+- [[remote-ssh]]
 - [google](https://google.com)

--- a/test/markdown/remote-ssh.md
+++ b/test/markdown/remote-ssh.md
@@ -1,0 +1,81 @@
+# Remote SSH Preview Test
+
+This file tests that the markdown preview works correctly when connected
+via **Remote SSH** from a Windows client to a Linux host ([#2224](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2224)).
+
+## Steps to reproduce
+
+1. Open this workspace on a **Linux remote** via VS Code Remote SSH from a **Windows** client
+2. Open this file and trigger **Markdown Preview Enhanced: Open Preview to the Side**
+3. Verify the preview renders without errors
+
+## Expected behavior
+
+- The preview renders normally below
+- No `"notebookPath is not valid"` errors appear in the Extension Host log
+  (open via **Developer: Show Logs...** → **Extension Host**)
+
+## What was broken
+
+When VS Code runs on a Windows client connected to a Linux remote, some
+internal URIs use Windows-style paths (`file:///c%3A/Users/...`). The
+`vscode-uri` library's `fsPath` strips the leading `/` for drive letters,
+producing `c:/Users/...` — which `path.isAbsolute()` on Linux returns
+`false` for. This caused `crossnote`'s `Notebook.init` to reject the
+path, spamming errors continuously.
+
+## Basic rendering check
+
+The preview should render the following content correctly:
+
+### Cross-file links (exercises path resolution)
+
+These links trigger `getWorkspaceFolderUri` to resolve the notebook path.
+**Test these on a Linux remote via Remote SSH from a Windows client.**
+
+- Relative link: [basics](./basics.md)
+- Relative link to subfolder: [CSV data](./data/sp500.csv)
+- Parent-relative link: [README](../markdown/README.md)
+- Wiki-link: [[basics]]
+- Wiki-link with heading: [[test#overview]]
+
+### File import (exercises notebook path + file system)
+
+@import "./basics.md" {line_begin=0, line_end=5}
+
+### Inline formatting
+
+**Bold**, _italic_, ~~strikethrough~~, `inline code`
+
+### List
+
+- Item 1
+- Item 2
+  - Nested item
+
+### Code block
+
+```js
+function hello() {
+  console.log('Preview is working!');
+}
+```
+
+### Math
+
+$E = mc^2$
+
+### Table
+
+| Feature    | Status     |
+| ---------- | ---------- |
+| Preview    | ✅ Working |
+| Remote SSH | ✅ Fixed   |
+
+### Image (placeholder)
+
+> If this renders as a blockquote, the preview is working.
+
+---
+
+_If you can see this rendered preview without errors in the Extension Host log, issue #2224 is fixed._


### PR DESCRIPTION
### Bug fixes

- Possible fix crash when using Remote SSH with a Windows client and Linux host — a Windows-style URI was passed to the Linux remote, producing an invalid notebook path that caused continuous `"notebookPath is not valid"` errors in the Extension Host log ([#2224](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2224))
- 