### PR TITLE
#2225 - Created solution for feature request to add preview lock functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New features
+
+- Preview locking: "Open Locked Preview to the Side" (`Ctrl+K Shift+L`) and "Toggle Preview Lock" (`Ctrl+K Ctrl+Shift+L`) commands to lock a preview to a specific file, preventing it from switching when the active editor changes ([#2225](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2225))
+
 ## [0.8.24] - 2026-04-21
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.22](https://github.com/shd101wyy/crossnote/releases/tag/0.9.22).
@@ -318,7 +322,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.4](h
 
 ### New features
 
-- Updated [fontawesome](https://fontawesome.com/) from version 4.7 to version 6.4.2 (Free).  
+- Updated [fontawesome](https://fontawesome.com/) from version 4.7 to version 6.4.2 (Free).
   A list of available icons can be found at: https://kapeli.com/cheat_sheets/Font_Awesome.docset/Contents/Resources/Documents/index
 - Updated WaveDrom to the latest version 3.3.0.
 
@@ -458,7 +462,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.20](
 
 ### New features
 
-- Supported prefix in front of Kroki diagram types https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1785.  
+- Supported prefix in front of Kroki diagram types https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1785.
   So now all diagrams below will get rendered using Kroki:
 
   ````markdown
@@ -492,18 +496,18 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.19](
 
 ### Changes
 
-- Deprecated the `processWikiLink` in `parser.js`. Now `crossnote` handles how we process the wiki link.  
+- Deprecated the `processWikiLink` in `parser.js`. Now `crossnote` handles how we process the wiki link.
   We also added two more options:
   - `wikiLinkTargetFileExtension`: The file extension of the target file. Default is `md`. For example:
     - `[[test]]` will be transformed to `[test](test.md)`
     - `[[test.md]]` will be transformed to `[test](test.md)`
     - `[[test.pdf]]` will be transformed to `[test](test.pdf)` because it has a file extension.
-  - `wikiLinkTargetFileNameChangeCase`: How we transform the file name. Default is `none` so we won't change the file name.  
+  - `wikiLinkTargetFileNameChangeCase`: How we transform the file name. Default is `none` so we won't change the file name.
     A list of available options can be found at: https://shd101wyy.github.io/crossnote/types/WikiLinkTargetFileNameChangeCase.html
 
 ### Bug fixes
 
-- Reverted the markdown transformer and deleted the logic of inserting anchor elements as it's causing a lot of problems.  
+- Reverted the markdown transformer and deleted the logic of inserting anchor elements as it's causing a lot of problems.
   The in-preview editor is not working as expected. So we now hide its highlight lines and elements feature if the markdown file failed to generate the correct source map.
 - Fixed the bug that global custom CSS is not working.
 
@@ -513,16 +517,16 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.17](
 
 ### New features
 
-- 📝 Supported in-preview editor that allows you to edit the markdown file directly in the preview 🎉.  
-  This feature is currently in beta.  
+- 📝 Supported in-preview editor that allows you to edit the markdown file directly in the preview 🎉.
+  This feature is currently in beta.
   When the editor is open, you can press `ctrl+s` or `cmd+s` to save the markdown file. You can also press `esc` to close the editor.
-- Deprecated the VS Code setting `markdown-preview-enhanced.singlePreview`.  
+- Deprecated the VS Code setting `markdown-preview-enhanced.singlePreview`.
   Now replaced by `markdown-preview-enhanced.previewMode`:
-  - **Single Preview** (_default_)  
+  - **Single Preview** (_default_)
     Only one preview will be shown for all editors.
-  - **Multiple Previews**  
+  - **Multiple Previews**
     Multiple previews will be shown. Each editor has its own preview.
-  - **Previews Only** 🆕  
+  - **Previews Only** 🆕
     No editor will be shown. Only previews will be shown. You can use the in-preview editor to edit the markdown.
 
     🔔 Please note that enable this option will automatically modify the `workbench.editorAssociations` setting to make sure the markdown files are opened in the custom editor for preview.
@@ -535,7 +539,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.17](
   ![](path/to/image.png){width=100 height=100}
   ```
 
-- Improved the markdown transformer to better insert anchors for scroll sync and highlight lines and elements.  
+- Improved the markdown transformer to better insert anchors for scroll sync and highlight lines and elements.
   Added more tests for the markdown transformer to make sure it works as expected.
 - Added the reading time estimation in the preview footer ⏲️.
 - Added `Edit Markdown` menu item to the context menu of the preview, which offers two options:
@@ -633,7 +637,7 @@ Fixed reading file as base64
 ### New features 🆕
 
 1. Complete rewrite of the webview, and improved the UI. 🌐💅
-2. Backlinks supported in the preview. Clicking the bottom right link icon will display the backlinks. This feature is currently in beta and might not be stable yet.  
+2. Backlinks supported in the preview. Clicking the bottom right link icon will display the backlinks. This feature is currently in beta and might not be stable yet.
    If you want the backlinks to be always on in the preview, you can enable the setting:
 
    ```

--- a/README.md
+++ b/README.md
@@ -54,17 +54,19 @@ Contact me if you are willing to help translate the documentation :)
 
 > The <kbd>cmd</kbd> key for _Windows_ is <kbd>ctrl</kbd>.
 
-| Shortcuts                                         | Functionality              |
-| ------------------------------------------------- | -------------------------- |
-| <kbd>cmd-k v</kbd> or <kbd>ctrl-k v</kbd>         | Open preview to the Side   |
-| <kbd>cmd-shift-v</kbd> or <kbd>ctrl-shift-v</kbd> | Open preview               |
-| <kbd>ctrl-shift-s</kbd>                           | Sync preview / Sync source |
-| <kbd>shift-enter</kbd>                            | Run Code Chunk             |
-| <kbd>ctrl-shift-enter</kbd>                       | Run all Code Chunks        |
-| <kbd>cmd-=</kbd> or <kbd>cmd-shift-=</kbd>        | Preview zoom in            |
-| <kbd>cmd--</kbd> or <kbd>cmd-shift-\_</kbd>       | Preview zoom out           |
-| <kbd>cmd-0</kbd>                                  | Preview reset zoom         |
-| <kbd>esc</kbd>                                    | Toggle sidebar TOC         |
+| Shortcuts                                                      | Functionality                   |
+| -------------------------------------------------------------- | ------------------------------- |
+| <kbd>cmd-k v</kbd> or <kbd>ctrl-k v</kbd>                      | Open preview to the Side        |
+| <kbd>cmd-shift-v</kbd> or <kbd>ctrl-shift-v</kbd>              | Open preview                    |
+| <kbd>cmd-k shift-l</kbd> or <kbd>ctrl-k shift-l</kbd>          | Open locked preview to the Side |
+| <kbd>cmd-k cmd-shift-l</kbd> or <kbd>ctrl-k ctrl-shift-l</kbd> | Toggle preview lock             |
+| <kbd>ctrl-shift-s</kbd>                                        | Sync preview / Sync source      |
+| <kbd>shift-enter</kbd>                                         | Run Code Chunk                  |
+| <kbd>ctrl-shift-enter</kbd>                                    | Run all Code Chunks             |
+| <kbd>cmd-=</kbd> or <kbd>cmd-shift-=</kbd>                     | Preview zoom in                 |
+| <kbd>cmd--</kbd> or <kbd>cmd-shift-\_</kbd>                    | Preview zoom out                |
+| <kbd>cmd-0</kbd>                                               | Preview reset zoom              |
+| <kbd>esc</kbd>                                                 | Toggle sidebar TOC              |
 
 ## Changelog
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
         }
       },
       {
+        "command": "markdown-preview-enhanced.openLockedPreviewToTheSide",
+        "title": "%markdown-preview-enhanced.openLockedPreviewToTheSide.title%",
+        "category": "Markdown"
+      },
+      {
+        "command": "markdown-preview-enhanced.togglePreviewLock",
+        "title": "%markdown-preview-enhanced.togglePreviewLock.title%",
+        "category": "Markdown"
+      },
+      {
         "command": "markdown-preview-enhanced.toggleScrollSync",
         "title": "%markdown-preview-enhanced.toggleScrollSync.title%"
       },
@@ -757,6 +767,18 @@
         "command": "markdown-preview-enhanced.openPreview",
         "key": "ctrl+shift+v",
         "mac": "cmd+shift+v",
+        "when": "editorLangId == markdown"
+      },
+      {
+        "command": "markdown-preview-enhanced.openLockedPreviewToTheSide",
+        "key": "ctrl+k shift+l",
+        "mac": "cmd+k shift+l",
+        "when": "editorLangId == markdown"
+      },
+      {
+        "command": "markdown-preview-enhanced.togglePreviewLock",
+        "key": "ctrl+k ctrl+shift+l",
+        "mac": "cmd+k cmd+shift+l",
         "when": "editorLangId == markdown"
       },
       {

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,8 @@
   "customEditorPreviewDisplayName": "Markdown Preview Enhanced",
   "markdown-preview-enhanced.openPreviewToTheSide.title": "Markdown Preview Enhanced: Open Preview to the Side",
   "markdown-preview-enhanced.openPreview.title": "Markdown Preview Enhanced: Open Preview",
+  "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "Markdown Preview Enhanced: Open Locked Preview to the Side",
+  "markdown-preview-enhanced.togglePreviewLock.title": "Markdown Preview Enhanced: Toggle Preview Lock",
   "markdown-preview-enhanced.toggleScrollSync.title": "Markdown Preview Enhanced: Toggle Scroll Sync",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "Markdown Preview Enhanced: Toggle Live Update",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "Markdown Preview Enhanced: Toggle Break On Single New Line",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -4,6 +4,8 @@
   "customEditorPreviewDisplayName": "Markdown 增强预览",
   "markdown-preview-enhanced.openPreviewToTheSide.title": "MPE:打开侧边预览",
   "markdown-preview-enhanced.openPreview.title": "MPE:打开预览",
+  "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:打开锁定的侧边预览",
+  "markdown-preview-enhanced.togglePreviewLock.title": "MPE:切换预览锁定",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:开关预览滑动同步",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:开关预览实时更新",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:开关回车换行",

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -108,6 +108,51 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
     });
   }
 
+  async function openLockedPreviewToTheSide(uri?: vscode.Uri) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
+    if (!uri) {
+      uri = editor.document.uri;
+    }
+
+    try {
+      const previewProvider = await getPreviewContentProvider(uri);
+      await previewProvider.initPreview({
+        sourceUri: uri,
+        document: editor.document,
+        cursorLine: getEditorActiveCursorLine(editor),
+        viewOptions: {
+          viewColumn: vscode.ViewColumn.Two,
+          preserveFocus: true,
+        },
+      });
+      previewProvider.lockSinglePreview();
+    } catch (error) {
+      console.error('[MPE] openLockedPreviewToTheSide failed:', error);
+      vscode.window.showErrorMessage(
+        `MPE Preview failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  async function togglePreviewLock(uri?: vscode.Uri) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
+    const previewProvider = await getPreviewContentProvider(
+      uri ?? editor.document.uri,
+    );
+    const locked = previewProvider.toggleSinglePreviewLock();
+    vscode.window.showInformationMessage(
+      locked
+        ? 'Preview is locked to the current file.'
+        : 'Preview is unlocked and will follow the active editor.',
+    );
+  }
+
   async function toggleScrollSync() {
     const scrollSync = !getMPEConfig<boolean>('scrollSync');
     await updateMPEConfig('scrollSync', scrollSync, true);
@@ -588,7 +633,7 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
         ) {
           /*
           // NOTE: This doesn't work for the `line`
-          // so we use the `initPreview` instead.  
+          // so we use the `initPreview` instead.
           const options: vscode.TextDocumentShowOptions = {
             selection: new vscode.Selection(line, 0, line, 0),
             viewColumn: vscode.ViewColumn.Active,
@@ -946,6 +991,10 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
               previewMode === PreviewMode.SinglePreview &&
               !previewProvider.previewHasTheSameSingleSourceUri(sourceUri)
             ) {
+              // Don't switch a locked preview to a different file
+              if (previewProvider.isSinglePreviewLocked()) {
+                return;
+              }
               // Skip auto-switching single preview to an excluded file
               if (!excluded) {
                 await previewProvider.initPreview({
@@ -1015,6 +1064,20 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'markdown-preview-enhanced.openPreview',
       openPreview,
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'markdown-preview-enhanced.openLockedPreviewToTheSide',
+      openLockedPreviewToTheSide,
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'markdown-preview-enhanced.togglePreviewLock',
+      togglePreviewLock,
     ),
   );
 

--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -128,6 +128,11 @@ export class PreviewProvider {
   public static notebooksManager: NotebooksManager | null = null;
 
   /**
+   * When true, the single preview does not follow the active text editor.
+   */
+  private static singlePreviewLocked = false;
+
+  /**
    * The key is markdown file fsPath
    * value is JSAndCssFiles
    */
@@ -439,6 +444,7 @@ export class PreviewProvider {
         // unregister previewPanel.
         previewPanel.onDidDispose(
           () => {
+            PreviewProvider.singlePreviewLocked = false;
             this.destroyPreview(sourceUri);
             this.destroyEngine(sourceUri);
             this.initializedPreviews.delete(previewPanel);
@@ -572,6 +578,42 @@ export class PreviewProvider {
         PreviewProvider.singlePreviewPanelSourceUriTarget.fsPath ===
         sourceUri.fsPath
       );
+    }
+  }
+
+  /**
+   * Returns true if the single preview is currently locked.
+   */
+  public isSinglePreviewLocked(): boolean {
+    return PreviewProvider.singlePreviewLocked;
+  }
+
+  /**
+   * Lock the single preview to its current file and update its title.
+   */
+  public lockSinglePreview() {
+    PreviewProvider.singlePreviewLocked = true;
+    this.updateSinglePreviewTitle();
+  }
+
+  /**
+   * Toggle lock on the single preview and update its title.
+   * Returns the new lock state.
+   */
+  public toggleSinglePreviewLock(): boolean {
+    PreviewProvider.singlePreviewLocked = !PreviewProvider.singlePreviewLocked;
+    this.updateSinglePreviewTitle();
+    return PreviewProvider.singlePreviewLocked;
+  }
+
+  private updateSinglePreviewTitle() {
+    const panel = PreviewProvider.singlePreviewPanel;
+    const sourceUri = PreviewProvider.singlePreviewPanelSourceUriTarget;
+    if (panel && sourceUri) {
+      const baseName = path.basename(sourceUri.fsPath);
+      panel.title = PreviewProvider.singlePreviewLocked
+        ? `Preview [Locked] ${baseName}`
+        : `Preview ${baseName}`;
     }
   }
 


### PR DESCRIPTION
**Issue [#2225](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2225)** — Markdown Preview Enhanced preview locking

Added two new commands with keyboard shortcuts:

| Command | Shortcut | Description |
|---------|----------|-------------|
| Open Locked Preview to the Side | `Ctrl+K Shift+L` | Opens a preview pinned to the current file |
| Toggle Preview Lock | `Ctrl+K Ctrl+Shift+L` | Toggles lock on/off for the existing preview |

When locked, the preview title shows `[Locked]` and the `onDidChangeActiveTextEditor` handler skips switching the preview content. Closing the preview panel automatically resets the lock.

### Changed files (7 files, +162 / -25)

- **preview-provider.ts** — Added `singlePreviewLocked` boolean flag, `isSinglePreviewLocked()`, `lockSinglePreview()`, `toggleSinglePreviewLock()`, and `updateSinglePreviewTitle()` helper
- **extension-common.ts** — Added `openLockedPreviewToTheSide` and `togglePreviewLock` command handlers; added lock guard in `onDidChangeActiveTextEditor`
- **package.json** — Registered both commands and keybindings
- **package.nls.json** — English localization strings
- **package.nls.zh.json** — Chinese localization strings
- **README.md** — Added keybindings to the shortcuts table