### PR TITLE
#2267 - Add click-to-enlarge image preview with lightbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New features
+
+- Add click-to-enlarge image lightbox in the preview — click any image to view it full-screen in an overlay; press Escape or click the backdrop to close. Controlled by the `enableImageLightbox` setting (default: `true`). ([vscode-mpe#2267](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2267))
+
 ## [0.8.24] - 2026-04-21
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.22](https://github.com/shd101wyy/crossnote/releases/tag/0.9.22).
@@ -318,7 +322,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.9.4](h
 
 ### New features
 
-- Updated [fontawesome](https://fontawesome.com/) from version 4.7 to version 6.4.2 (Free).  
+- Updated [fontawesome](https://fontawesome.com/) from version 4.7 to version 6.4.2 (Free).
   A list of available icons can be found at: https://kapeli.com/cheat_sheets/Font_Awesome.docset/Contents/Resources/Documents/index
 - Updated WaveDrom to the latest version 3.3.0.
 
@@ -458,7 +462,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.20](
 
 ### New features
 
-- Supported prefix in front of Kroki diagram types https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1785.  
+- Supported prefix in front of Kroki diagram types https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1785.
   So now all diagrams below will get rendered using Kroki:
 
   ````markdown
@@ -492,18 +496,18 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.19](
 
 ### Changes
 
-- Deprecated the `processWikiLink` in `parser.js`. Now `crossnote` handles how we process the wiki link.  
+- Deprecated the `processWikiLink` in `parser.js`. Now `crossnote` handles how we process the wiki link.
   We also added two more options:
   - `wikiLinkTargetFileExtension`: The file extension of the target file. Default is `md`. For example:
     - `[[test]]` will be transformed to `[test](test.md)`
     - `[[test.md]]` will be transformed to `[test](test.md)`
     - `[[test.pdf]]` will be transformed to `[test](test.pdf)` because it has a file extension.
-  - `wikiLinkTargetFileNameChangeCase`: How we transform the file name. Default is `none` so we won't change the file name.  
+  - `wikiLinkTargetFileNameChangeCase`: How we transform the file name. Default is `none` so we won't change the file name.
     A list of available options can be found at: https://shd101wyy.github.io/crossnote/types/WikiLinkTargetFileNameChangeCase.html
 
 ### Bug fixes
 
-- Reverted the markdown transformer and deleted the logic of inserting anchor elements as it's causing a lot of problems.  
+- Reverted the markdown transformer and deleted the logic of inserting anchor elements as it's causing a lot of problems.
   The in-preview editor is not working as expected. So we now hide its highlight lines and elements feature if the markdown file failed to generate the correct source map.
 - Fixed the bug that global custom CSS is not working.
 
@@ -513,16 +517,16 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.17](
 
 ### New features
 
-- 📝 Supported in-preview editor that allows you to edit the markdown file directly in the preview 🎉.  
-  This feature is currently in beta.  
+- 📝 Supported in-preview editor that allows you to edit the markdown file directly in the preview 🎉.
+  This feature is currently in beta.
   When the editor is open, you can press `ctrl+s` or `cmd+s` to save the markdown file. You can also press `esc` to close the editor.
-- Deprecated the VS Code setting `markdown-preview-enhanced.singlePreview`.  
+- Deprecated the VS Code setting `markdown-preview-enhanced.singlePreview`.
   Now replaced by `markdown-preview-enhanced.previewMode`:
-  - **Single Preview** (_default_)  
+  - **Single Preview** (_default_)
     Only one preview will be shown for all editors.
-  - **Multiple Previews**  
+  - **Multiple Previews**
     Multiple previews will be shown. Each editor has its own preview.
-  - **Previews Only** 🆕  
+  - **Previews Only** 🆕
     No editor will be shown. Only previews will be shown. You can use the in-preview editor to edit the markdown.
 
     🔔 Please note that enable this option will automatically modify the `workbench.editorAssociations` setting to make sure the markdown files are opened in the custom editor for preview.
@@ -535,7 +539,7 @@ Updated [crossnote](https://github.com/shd101wyy/crossnote) to version [0.8.17](
   ![](path/to/image.png){width=100 height=100}
   ```
 
-- Improved the markdown transformer to better insert anchors for scroll sync and highlight lines and elements.  
+- Improved the markdown transformer to better insert anchors for scroll sync and highlight lines and elements.
   Added more tests for the markdown transformer to make sure it works as expected.
 - Added the reading time estimation in the preview footer ⏲️.
 - Added `Edit Markdown` menu item to the context menu of the preview, which offers two options:
@@ -633,7 +637,7 @@ Fixed reading file as base64
 ### New features 🆕
 
 1. Complete rewrite of the webview, and improved the UI. 🌐💅
-2. Backlinks supported in the preview. Clicking the bottom right link icon will display the backlinks. This feature is currently in beta and might not be stable yet.  
+2. Backlinks supported in the preview. Clicking the bottom right link icon will display the backlinks. This feature is currently in beta and might not be stable yet.
    If you want the backlinks to be always on in the preview, you can enable the setting:
 
    ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default tseslint.config(
       'eslint.config.mjs',
       '.yarn/**',
       'test/**',
+      'media/**',
       'prettier.config.js',
     ],
   },

--- a/media/lightbox.css
+++ b/media/lightbox.css
@@ -1,0 +1,36 @@
+/* Lightbox overlay for click-to-enlarge image preview */
+.mpe-lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 100000;
+  cursor: zoom-out;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.mpe-lightbox-overlay.mpe-lightbox-visible {
+  display: flex;
+  opacity: 1;
+}
+
+.mpe-lightbox-overlay img {
+  max-width: 95vw;
+  max-height: 95vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* Zoom-in cursor hint on previewable images */
+.preview-container img:not(.mpe-lightbox-overlay img) {
+  cursor: zoom-in;
+}

--- a/media/lightbox.js
+++ b/media/lightbox.js
@@ -1,0 +1,74 @@
+// Lightbox: click-to-enlarge image preview for Markdown Preview Enhanced
+(function () {
+  'use strict';
+
+  var overlay;
+  var lightboxImg;
+
+  function createOverlay() {
+    overlay = document.createElement('div');
+    overlay.className = 'mpe-lightbox-overlay';
+    lightboxImg = document.createElement('img');
+    overlay.appendChild(lightboxImg);
+    document.body.appendChild(overlay);
+
+    overlay.addEventListener('click', close);
+  }
+
+  function open(src) {
+    if (!overlay) {
+      createOverlay();
+    }
+    lightboxImg.src = src;
+    // Force reflow before adding the visible class for the CSS transition
+    overlay.style.display = 'flex';
+    void overlay.offsetHeight;
+    overlay.classList.add('mpe-lightbox-visible');
+  }
+
+  function close() {
+    if (!overlay) {
+      return;
+    }
+    overlay.classList.remove('mpe-lightbox-visible');
+    // After transition, hide completely
+    setTimeout(function () {
+      if (!overlay.classList.contains('mpe-lightbox-visible')) {
+        overlay.style.display = 'none';
+        lightboxImg.src = '';
+      }
+    }, 200);
+  }
+
+  // Use event delegation so dynamically updated content is handled
+  document.addEventListener(
+    'click',
+    function (e) {
+      var img = e.target;
+      if (
+        img &&
+        img.tagName === 'IMG' &&
+        !img.closest('.mpe-lightbox-overlay')
+      ) {
+        var src = img.getAttribute('src');
+        if (src) {
+          e.preventDefault();
+          e.stopPropagation();
+          open(src);
+        }
+      }
+    },
+    true,
+  );
+
+  document.addEventListener('keydown', function (e) {
+    if (
+      e.key === 'Escape' &&
+      overlay &&
+      overlay.classList.contains('mpe-lightbox-visible')
+    ) {
+      e.preventDefault();
+      close();
+    }
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -731,6 +731,11 @@
           "description": "Enable this option will hide unnecessary UI elements in preview unless your mouse is over it.",
           "default": true,
           "type": "boolean"
+        },
+        "markdown-preview-enhanced.enableImageLightbox": {
+          "description": "Click an image in the preview to view it in a full-screen lightbox overlay. Press Escape or click the backdrop to close.",
+          "default": true,
+          "type": "boolean"
         }
       }
     },

--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -475,6 +475,26 @@ export class PreviewProvider {
       const initRequestId = ++this.initRequestSeq;
       this.latestInitRequestByPreview.set(previewPanel, initRequestId);
 
+      // Build lightbox head injection when enabled
+      let head = '';
+      if (getMPEConfig<boolean>('enableImageLightbox') ?? true) {
+        const lightboxCssUri = previewPanel.webview.asWebviewUri(
+          vscode.Uri.joinPath(
+            this.context.extensionUri,
+            'media',
+            'lightbox.css',
+          ),
+        );
+        const lightboxJsUri = previewPanel.webview.asWebviewUri(
+          vscode.Uri.joinPath(
+            this.context.extensionUri,
+            'media',
+            'lightbox.js',
+          ),
+        );
+        head = `<link rel="stylesheet" href="${lightboxCssUri}"><script defer src="${lightboxJsUri}"></script>`;
+      }
+
       const html = await engine.generateHTMLTemplateForPreview({
         inputString,
         config: {
@@ -493,7 +513,7 @@ export class PreviewProvider {
         // runtime using the full sourceUri, so we can safely omit it here.
         // For the native extension the default base tag is harmless, but we keep
         // consistent behaviour and let React own it in both cases.
-        head: '',
+        head,
       });
 
       // If a newer initPreview call has taken over this panel, or the panel was

--- a/test/markdown/test-lightbox.md
+++ b/test/markdown/test-lightbox.md
@@ -1,0 +1,25 @@
+# Lightbox Test
+
+Click any image to enlarge. Press **Escape** or click the backdrop to close.
+
+## Screenshot (1920×1080)
+
+<img src="https://picsum.photos/seed/screenshot/1920/1080" alt="High-res screenshot" width="300">
+
+## Diagram (2400×800)
+
+<img src="https://picsum.photos/seed/diagram/2400/800" alt="Architecture diagram" width="350">
+
+## UI Mockup (1440×900)
+
+<img src="https://picsum.photos/seed/mockup/1440/900" alt="UI mockup" width="250">
+
+## Multiple inline images
+
+<img src="https://picsum.photos/seed/partA/800/600" alt="Part A" width="150"> <img src="https://picsum.photos/seed/partB/800/600" alt="Part B" width="150"> <img src="https://picsum.photos/seed/partC/800/600" alt="Part C" width="150">
+
+## Small image (64×64)
+
+![Icon](https://picsum.photos/seed/icon/64/64)
+
+Setting: `enableImageLightbox` (default `true`).


### PR DESCRIPTION
Issue [#2267](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2267) — Add click-to-enlarge image preview / lightbox in Markdown preview.

Inline images are often too small to inspect details. This adds a full-screen lightbox overlay that opens when clicking any image in the preview. Press **Escape** or click the backdrop to close.

### Changes

1. **lightbox.css** — Overlay styling: dark backdrop, centered image, fade transition, zoom cursors.
2. **lightbox.js** — Event-delegated click handler on `<img>` elements. Lazy-creates the overlay on first use. Closes on Escape or backdrop click.
3. **preview-provider.ts** — Injects lightbox CSS/JS into the preview `<head>` via `asWebviewUri()` when the setting is enabled.
4. **package.json** — New `enableImageLightbox` setting (boolean, default `true`).
5. **eslint.config.mjs** — Added `media/**` to ignores.
6. **test-lightbox.md** — Manual test file with various image sizes and layouts.