### PR TITLE
Added contextmenu inherit VS Code theme settings option

### DIFF
--- a/package.json
+++ b/package.json
@@ -731,6 +731,11 @@
           "description": "Enable this option will hide unnecessary UI elements in preview unless your mouse is over it.",
           "default": true,
           "type": "boolean"
+        },
+        "markdown-preview-enhanced.useVSCodeThemeForContextMenu": {
+          "description": "When enabled, the context menu in preview inherits VS Code's theme colors and font instead of the default styling.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },
@@ -817,7 +822,7 @@
     "@types/crypto-js": "^4.1.2",
     "@types/vfile": "^3.0.2",
     "async-mutex": "^0.4.0",
-    "crossnote": "^0.9.22",
+    "crossnote": "^0.9.23",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,7 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
   public readonly webSequenceDiagramsApiKey: string;
   public readonly alwaysShowBacklinksInPreview: boolean;
   public readonly enablePreviewZenMode: boolean;
+  public readonly useVSCodeThemeForContextMenu: boolean;
   public readonly wikiLinkTargetFileExtension: string;
   public readonly wikiLinkTargetFileNameChangeCase: WikiLinkTargetFileNameChangeCase;
   // D2 diagram settings
@@ -282,6 +283,9 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
     this.enablePreviewZenMode =
       getMPEConfig<boolean>('enablePreviewZenMode') ??
       defaultConfig.enablePreviewZenMode;
+    this.useVSCodeThemeForContextMenu =
+      getMPEConfig<boolean>('useVSCodeThemeForContextMenu') ??
+      defaultConfig.useVSCodeThemeForContextMenu;
     this.wikiLinkTargetFileExtension =
       getMPEConfig<string>('wikiLinkTargetFileExtension') ??
       defaultConfig.wikiLinkTargetFileExtension;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,10 +2580,8 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crossnote@^0.9.22:
-  version "0.9.22"
-  resolved "https://registry.yarnpkg.com/crossnote/-/crossnote-0.9.22.tgz#328ea49f3ceeefed2200c75137ef393f4f0bb12e"
-  integrity sha512-/kQqS3jtH5FuJFOgWbc/puW1rf6QcYbBLtljnTHmdo0RN/Huzdz0myf/JvkovQfyKvXaNPSK1Db94lM7h3JaoQ==
+crossnote@^0.9.23:
+  version "0.9.23"
   dependencies:
     "@headlessui/react" "^1.7.17"
     "@heroicons/react" "^2.0.18"


### PR DESCRIPTION
Depends on PR: https://github.com/shd101wyy/crossnote/pull/419

Wires up the new crossnote `useVSCodeThemeForContextMenu` config option so users can toggle it from VS Code settings.

**Changes:**
- **package.json** — Added `markdown-preview-enhanced.useVSCodeThemeForContextMenu` boolean setting (default `false`) under `contributes.configuration`. Also bumped the crossnote dependency from `^0.9.22` to `^0.9.23`.
- **config.ts** — Added `useVSCodeThemeForContextMenu` property to `MarkdownPreviewEnhancedConfig` and wired it to read from VS Code settings via `getMPEConfig()`, falling back to crossnote's default.

It introduces this new setting
<img width="887" height="71" alt="image" src="https://github.com/user-attachments/assets/17189e25-e6ce-49bc-a878-f8e749f0d7ae" />