### PR TITLE
feat: add automaticallyOpenPreviewOnFileOpen config

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,11 @@
           "default": false,
           "type": "boolean"
         },
+        "markdown-preview-enhanced.automaticallyOpenPreviewOnFileOpen": {
+          "description": "Automatically open preview in the same column without splitting when a markdown file is opened or activated.",
+          "default": false,
+          "type": "boolean"
+        },
         "markdown-preview-enhanced.disableAutoPreviewForUriSchemes": {
           "markdownDescription": "A list of URI schemes (e.g., `vscode-notebook-cell`) to exclude from the `automaticallyShowPreviewOfMarkdownBeingEdited` feature. Files matching these schemes won't trigger the automatic preview.",
           "default": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ export enum PreviewColorScheme {
 
 type VSCodeMPEConfigKey =
   | 'automaticallyShowPreviewOfMarkdownBeingEdited'
+  | 'automaticallyOpenPreviewOnFileOpen'
   | 'configPath'
   | 'enableImageLightbox'
   | 'imageUploader'
@@ -127,6 +128,7 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
 
   // preview config
   public readonly automaticallyShowPreviewOfMarkdownBeingEdited: boolean;
+  public readonly automaticallyOpenPreviewOnFileOpen: boolean;
   public readonly hideDefaultVSCodeMarkdownPreviewButtons: boolean;
   public readonly imageUploader: ImageUploader;
   public readonly liveUpdate: boolean;
@@ -240,6 +242,8 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
     this.automaticallyShowPreviewOfMarkdownBeingEdited =
       getMPEConfig<boolean>('automaticallyShowPreviewOfMarkdownBeingEdited') ??
       false;
+    this.automaticallyOpenPreviewOnFileOpen =
+      getMPEConfig<boolean>('automaticallyOpenPreviewOnFileOpen') ?? false;
     this.previewColorScheme =
       getMPEConfig<PreviewColorScheme>('previewColorScheme') ??
       PreviewColorScheme.selectedPreviewTheme;

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -1173,6 +1173,9 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
             getMPEConfig<boolean>(
               'automaticallyShowPreviewOfMarkdownBeingEdited',
             );
+          const automaticallyOpenPreviewOnFileOpen = getMPEConfig<boolean>(
+            'automaticallyOpenPreviewOnFileOpen',
+          );
           const previewMode = getPreviewMode();
           /**
            * Is using single preview and the preview is on.
@@ -1209,8 +1212,11 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
               }
             }
             // NOTE: For PreviewMode.PreviewsOnly, we don't need to do anything.
+          } else if (automaticallyOpenPreviewOnFileOpen) {
+            if (!excluded) {
+              openPreview(sourceUri);
+            }
           } else if (automaticallyShowPreviewOfMarkdownBeingEdited) {
-            // Skip auto-opening preview for an excluded file
             if (!excluded) {
               openPreviewToTheSide(sourceUri);
             }


### PR DESCRIPTION
## Summary

- Add new config `automaticallyOpenPreviewOnFileOpen` (default: `false`)
- When enabled, automatically opens preview in the same column without splitting when a markdown file is opened or activated
- Different from `automaticallyShowPreviewOfMarkdownBeingEdited` which opens a side-by-side split preview

## Motivation

Users who prefer a single-column layout had no way to auto-open preview without triggering a split. This config fills that gap.

## Changes

- `package.json`: declare new config with description and default
- `src/config.ts`: add class property and constructor assignment
- `src/extension-common.ts`: read config and call `openPreview` (ViewColumn.One) when enabled

## Test Plan

- [x] Enable `automaticallyOpenPreviewOnFileOpen` — preview opens in same column, no split
- [x] Disable `automaticallyOpenPreviewOnFileOpen` — no auto-open on file open