### PR TITLE
fix: use ViewColumn.Beside instead of ViewColumn.Two for openPreviewToTheSide

### DIFF
--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -83,7 +83,7 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
         document: editor.document,
         cursorLine: getEditorActiveCursorLine(editor),
         viewOptions: {
-          viewColumn: vscode.ViewColumn.Two,
+          viewColumn: vscode.ViewColumn.Beside,
           preserveFocus: true,
         },
       });
@@ -132,7 +132,7 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
         document: editor.document,
         cursorLine: getEditorActiveCursorLine(editor),
         viewOptions: {
-          viewColumn: vscode.ViewColumn.Two,
+          viewColumn: vscode.ViewColumn.Beside,
           preserveFocus: true,
         },
       });


### PR DESCRIPTION
## Problem

`openPreviewToTheSide` and `openLockedPreviewToTheSide` use `vscode.ViewColumn.Two` (fixed value `2`) to position the preview panel. This requires a second editor group to already exist.

In newer versions of VS Code / Cursor (3.x), when only one editor group is open, `ViewColumn.Two` no longer auto-creates a split — the panel opens as a tab in the same group, making `openPreviewToTheSide` behave identically to `openPreview`.

## Root Cause

| Value | Meaning | Behavior |
|-------|---------|----------|
| `ViewColumn.Two = 2` | Fixed reference to 2nd editor group | Only works if a 2nd group already exists |
| `ViewColumn.Beside = -2` | Symbolic: "beside the active editor" | **Always** creates a split when needed |

The VS Code API docs confirm that `ViewColumn.Beside` is the correct value for "open to the side" semantics:
> "A *symbolic* editor column representing the column **to the side of the active one**."

`ViewColumn.Two` JSDoc only says: "The second editor column." — no guarantee of creating a split.

## Note

Interestingly, line 1208 of `extension-common.ts` already has `/*vscode.ViewColumn.Two*/ undefined` commented out, suggesting this issue was partially recognized previously.

## Fix

Replace `vscode.ViewColumn.Two` with `vscode.ViewColumn.Beside` in both `openPreviewToTheSide` and `openLockedPreviewToTheSide`.

## Testing

Verified with Cursor 3.2.16 + MPE 0.8.25: after patching the compiled `extension.js` with `ViewColumn.Beside`, `openPreviewToTheSide` correctly opens the preview in a split editor even when starting from a single editor group.

**References:**
- [VS Code API — ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn)
- [window.createWebviewPanel](https://code.visualstudio.com/api/references/vscode-api#window.createWebviewPanel)