### PR TITLE
fix: make refreshPreview reflect external file edits

### DIFF
--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -332,12 +332,14 @@ export class PreviewProvider {
     webviewPanel,
     cursorLine,
     viewOptions,
+    inputStringOverride,
   }: {
     sourceUri: vscode.Uri;
     document: vscode.TextDocument;
     webviewPanel?: vscode.WebviewPanel;
     cursorLine?: number;
     viewOptions: { viewColumn: vscode.ViewColumn; preserveFocus?: boolean };
+    inputStringOverride?: string;
   }): Promise<void> {
     const previewMode = getPreviewMode();
     let previewPanel: vscode.WebviewPanel;
@@ -473,7 +475,7 @@ export class PreviewProvider {
       initialLine = cursorLine;
     }
 
-    const inputString = document.getText() ?? '';
+    const inputString = inputStringOverride ?? document.getText() ?? '';
     const engine = this.getEngine(sourceUri);
     try {
       // Tag this request so we can detect if a newer initPreview overtook us
@@ -766,28 +768,46 @@ export class PreviewProvider {
     })();
   }
 
-  private refreshPreviewPanel(sourceUri: Uri | null) {
+  private async refreshPreviewPanel(sourceUri: Uri | null) {
     if (!sourceUri) {
       return;
     }
 
-    this.previewToDocumentMap.forEach(async (document, previewPanel) => {
+    for (const [previewPanel, document] of this.previewToDocumentMap) {
       if (
-        previewPanel &&
-        isMarkdownFile(document) &&
-        document.uri &&
-        document.uri.fsPath === sourceUri.fsPath
+        !previewPanel ||
+        !isMarkdownFile(document) ||
+        !document.uri ||
+        document.uri.fsPath !== sourceUri.fsPath
       ) {
-        await this.initPreview({
-          sourceUri,
-          document,
-          viewOptions: {
-            viewColumn: previewPanel.viewColumn ?? vscode.ViewColumn.One,
-            preserveFocus: true,
-          },
-        });
+        continue;
       }
-    });
+
+      // Force re-reading from disk so manual refresh works even when the file
+      // was modified by an external editor (e.g. across the WSL boundary, or
+      // by notepad.exe) and VSCode did not pick up the change. Skip when the
+      // buffer has unsaved edits — those would otherwise be overwritten by
+      // the older on-disk content.
+      let inputStringOverride: string | undefined;
+      if (!document.isDirty) {
+        try {
+          const data = await vscode.workspace.fs.readFile(sourceUri);
+          inputStringOverride = Buffer.from(data).toString('utf-8');
+        } catch {
+          // Fall back to the cached document content on read failure.
+        }
+      }
+
+      await this.initPreview({
+        sourceUri,
+        document,
+        inputStringOverride,
+        viewOptions: {
+          viewColumn: previewPanel.viewColumn ?? vscode.ViewColumn.One,
+          preserveFocus: true,
+        },
+      });
+    }
   }
 
   public refreshPreview(sourceUri: Uri) {

--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -364,6 +364,7 @@ export class PreviewProvider {
           document,
           viewOptions,
           cursorLine,
+          inputStringOverride,
         });
       } else {
         previewPanel = PreviewProvider.singlePreviewPanel;
@@ -378,6 +379,7 @@ export class PreviewProvider {
             webviewPanel: preview,
             viewOptions,
             cursorLine,
+            inputStringOverride,
           }),
         ),
       );
@@ -679,7 +681,21 @@ export class PreviewProvider {
         renderRequestId,
       );
 
-      const text = document.getText();
+      // Prefer disk content when the buffer has no unsaved edits, so that
+      // external file modifications (e.g. across the WSL boundary or by
+      // notepad.exe) propagate to the preview even when VSCode did not
+      // refresh its cached TextDocument. Reads happen after the stamp so the
+      // existing stale-render guard below still discards us if a newer
+      // updateMarkdown overtakes during the disk read.
+      let text = document.getText();
+      if (!document.isDirty) {
+        try {
+          const data = await vscode.workspace.fs.readFile(sourceUri);
+          text = Buffer.from(data).toString('utf-8');
+        } catch {
+          // Fall back to the cached document content on read failure.
+        }
+      }
       await this.postMessageToPreview(sourceUri, {
         command: 'startParsingMarkdown',
       });


### PR DESCRIPTION
## Summary

- Make the "Refresh the preview" command (toolbar refresh icon /
  `_crossnote.refreshPreview`) re-read the markdown source from disk
  instead of using VSCode's cached `TextDocument`, so external edits
  that VSCode did not pick up still propagate to the preview on manual
  refresh.
- Behavior for unsaved buffers is preserved: when `document.isDirty`,
  the cached `TextDocument` content is used (no clobbering of in-flight
  edits).

## Motivation

When a markdown file is modified outside VSCode (e.g. from another
editor, across the WSL boundary, or by `notepad.exe`'s atomic save),
VSCode's file watcher does not always pick up the change and the
in-memory `TextDocument` stays stale. Pressing the preview's refresh
button does not help because the existing code path passes the cached
`TextDocument.getText()` to the engine. The preview only updates after
`Developer: Reload Window`.

This PR fixes the manual refresh path so it always reflects the latest
on-disk content when the buffer is clean.

## Changes

`src/preview-provider.ts`:

- `refreshPreviewPanel`:
  - Read the latest content with `vscode.workspace.fs.readFile()` when
    `document.isDirty === false`, and pass it as `inputStringOverride`
    to `initPreview`.
  - Convert the orphaned `forEach(async ...)` into a serial `for...of`
    loop so the `await` on `initPreview` actually serializes.
  - Make the method `async`. All call sites are fire-and-forget; no
    change needed there.
- `initPreview`:
  - Accept an optional `inputStringOverride` parameter. When omitted,
    behavior is unchanged.
  - Forward `inputStringOverride` through both recursive calls
    (single-preview reset path and multi-preview fan-out) so the
    on-disk content survives the recursion.
- `updateMarkdown`:
  - Apply the same disk-read-when-clean strategy. This is necessary
    because the webview, after `webview.html` is reassigned, fires
    `webviewFinishLoading`, which calls `updateMarkdown` and would
    otherwise post `updateHtml` with the cached document content,
    clobbering the freshly rendered new content within a tick.

No new dependencies.

## Behavior matrix

| Trigger | `document.isDirty` | Source used | Notes |
|---|---|---|---|
| Refresh button | `false` | Disk | Main fix |
| Refresh button | `true` | Cached `TextDocument` | Preserves unsaved edits |
| Save | `false` | Disk | Equivalent content; no regression |
| Live edit (`onDidChangeTextDocument`) | `true` | Cached `TextDocument` | Unchanged |
| Webview reload (`webviewFinishLoading`) | `false` | Disk | Stays consistent with first render |

## Test plan

- [ ] Open a markdown file in VSCode, ensure preview is open
- [ ] Modify the file from outside VSCode (e.g. another editor, vim
      from a WSL terminal, notepad on Windows)
- [ ] Click the preview toolbar refresh icon → preview should now show
      the latest content
- [ ] Verify unsaved edits are not lost: edit the buffer, do NOT save,
      click refresh → preview should still reflect the unsaved buffer
- [ ] Verify normal in-editor live edit still updates the preview
      automatically