### PR TITLE
fix: load global config from local fs regardless of workspace remote

### DIFF
--- a/src/notebooks-manager.ts
+++ b/src/notebooks-manager.ts
@@ -94,9 +94,15 @@ class NotebooksManager {
     let globalConfig: Partial<NotebookConfig> = {};
     if (!isVSCodeWebExtension()) {
       try {
+        // Global config always lives on the same machine where the extension
+        // host runs, regardless of whether the workspace is on a remote host
+        // (WSL/SSH). Using notebook.fs here would inherit the workspace's
+        // authority and misroute the URI (e.g. file://wsl.localhost/C:/...),
+        // which silently drops the user's ~/.crossnote customizations.
+        const localFs = wrapVSCodeFSAsApi('file', '');
         globalConfig = await loadConfigsInDirectory(
           globalConfigPath,
-          notebook.fs,
+          localFs,
           true,
         );
       } catch (error) {


### PR DESCRIPTION
## Summary

Restore loading of the global `~/.crossnote` config (`style.less`,
`config.js`, `parser.js`, `head.html`) when the workspace lives on a
remote host (WSL via `\\wsl.localhost\` UNC paths, SSH-Remote
workspaces). Since 0.8.23 these customizations have been silently
dropped in those setups.

## Motivation

0.8.23 refactored `wrapVSCodeFSAsApi` to take an `authority` argument
so that the notebook's `fs` could address workspace files on remote
hosts:

```ts
function getUri(filePath: string, scheme: string, authority: string) {
  return vscode.Uri.from({ scheme, authority, path: filePath });
}
```

This is correct for workspace files. But `loadNotebookConfig` also uses
the notebook's `fs` to load the **global** config:

```ts
globalConfig = await loadConfigsInDirectory(
  globalConfigPath,   // always an absolute path on the local machine
  notebook.fs,        // inherits the workspace's authority
  true,
);
```

`globalConfigPath` always points at the machine where the extension
host runs — but `notebook.fs` carries the workspace's `authority`. So
when the workspace is on WSL, the URI for the user's `style.less`
becomes:

```
file://wsl.localhost/C:/Users/<user>/.crossnote/style.less
```

That URI does not exist (WSL has no `/C:/...` path), `fs.exists()`
returns false, and the loader silently returns an empty config. The
user's preview/export styles, parser hooks, MathJax/KaTeX/Mermaid
config, and `head.html` are all dropped without any warning.

Same issue affects SSH-Remote workspaces.

## Fix

Use a dedicated local fs (empty `authority`) for the global config
load. The workspace config load below it continues to use
`notebook.fs`, which is correct (workspace config lives next to the
workspace on the same host).

```ts
const localFs = wrapVSCodeFSAsApi('file', '');
globalConfig = await loadConfigsInDirectory(
  globalConfigPath,
  localFs,
  true,
);
```

5 lines of comment + 1 line replacement + 1 line added (the `localFs`
declaration).

## Scope check — other `globalConfigPath` uses

| File:line | How `globalConfigPath` is used | Affected? |
|---|---|---|
| `src/extension.ts:15,16,19,38,...` | Native Node `fs` API (extension host process) | No, always local |
| `src/notebooks-manager.ts:104` | `notebook.fs` | **Yes — this PR** |
| `src/preview-provider.ts:389` | `vscode.Uri.file(globalConfigPath)` for webview `localResourceRoots` | No, `vscode.Uri.file` produces a local `file:///` URI |

No other places need to change.

## Behavior matrix

| Scenario | workspace authority | Before | After |
|---|---|---|---|
| Linux/Mac local | `''` | OK (coincidental match) | unchanged |
| Windows local md | `''` | OK | unchanged |
| Windows + WSL UNC (`\\wsl.localhost\`) | `wsl.localhost` | broken | fixed |
| Windows + SSH-Remote workspace | `ssh-remote+host` | broken | fixed |
| Remote-WSL (`vscode-remote` scheme; extension runs in WSL server) | `''` from server's view | OK | unchanged |
| VSCode Web extension | — | skipped by `!isVSCodeWebExtension()` guard | unchanged |

## Test plan

- [ ] On Windows, create some custom styles in `C:\Users\<user>\.crossnote\style.less` (e.g. change the preview font)
- [ ] Open a markdown file on a local Windows path → preview shows the custom style (regression check; should still work)
- [ ] Open a markdown file on a WSL path via `\\wsl.localhost\<distro>\...` → preview now shows the custom style (was previously dropped)
- [ ] If you have SSH-Remote available: open a file there from the host machine's VSCode → preview shows the host's global custom style