### PR TITLE
fix: ensure note index is built before resolveWikilink for shortest mode (Ctrl+Click)

### DIFF
--- a/src/wikilink-document-link-provider.ts
+++ b/src/wikilink-document-link-provider.ts
@@ -211,6 +211,15 @@ async function resolveWikilinkUri(
   if (notebook) {
     const rootFsPath = notebook.notebookPath.fsPath;
     const currentRelPath = path.relative(rootFsPath, sourceUri.fsPath);
+    // shortest mode searches the note index — ensure it is populated.
+    // relative and absolute modes compute paths purely from the link string
+    // and never access this.notes, so no indexing is needed for them.
+    if (notebook.config.wikiLinkResolution === 'shortest') {
+      await notebook.refreshNotesIfNotLoaded({
+        dir: '.',
+        includeSubdirectories: true,
+      });
+    }
     const resolvedRel = notebook.resolveWikilink(fileName, currentRelPath);
     return vscode.Uri.file(path.join(rootFsPath, resolvedRel));
   }


### PR DESCRIPTION
## Summary

Companion to **shd101wyy/crossnote#434** (which fixes the same issue for the HTML preview rendering path).

---

### Problem

`resolveWikilinkUri` — the `DocumentLinkProvider` handler for **Ctrl+Click** on `[[wikilinks]]` in the editor — calls `notebook.resolveWikilink()` in `shortest` mode without first ensuring the note index is populated.

The note index (`this.notes`) is populated lazily when the user opens **Backlinks** or **Graph View**.  On the first Ctrl+Click in `shortest` mode the index was therefore empty, so `resolveWikilink` could not find any matching notes and fell back to resolving the link relative to the current file's directory.  This caused two visible symptoms:

- Navigating to the **wrong file** (e.g. `[[test]]` in `sub/dir/note.md` opens `sub/dir/test.md` instead of root-level `test.md`)
- **Creating a wrong stub file** at that wrong path when the file did not exist

`relative` and `absolute` modes were unaffected — they compute the target path purely from the link string and never access `this.notes`.

---

### Fix

One guard added in `src/wikilink-document-link-provider.ts`, inside `resolveWikilinkUri`:

```ts
if (notebook.config.wikiLinkResolution === 'shortest') {
  await notebook.refreshNotesIfNotLoaded({
    dir: '.',
    includeSubdirectories: true,
  });
}
```

`refreshNotesIfNotLoaded` is protected by an internal Mutex in crossnote, so concurrent calls (e.g. multiple links resolved in quick succession) are safe.

---

### Relationship to crossnote#434

The three remaining bugs fixed in crossnote#434 (preview `<a href>` coordinate system, Windows path separator in tie-breaking, empty index on render) all live inside crossnote itself.  This PR covers the one piece that lives in this repository: the editor Ctrl+Click handler.

Once crossnote#434 is merged and a new crossnote version is published, this extension will automatically pick up the preview-side fixes.  This PR provides the editor-side fix independently.