### PR TITLE
fix: preserve webview-resource authority when handling preview link clicks

### DIFF
--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -675,9 +675,24 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
       .replace(/^vscode-resource:\/\//, '')
       .replace(/^vscode-webview-resource:\/\/(.+?)\//, '')
       .replace(/^file\/\/\//, '${scheme}:///')
+      // VSCode's webview resource URLs encode the source URI's authority
+      // into the host as `file+<encoded-authority>.vscode-resource.vscode-cdn.net`.
+      // Non-[a-z0-9-] chars in the authority are encoded as `-XXXX` (4-digit
+      // hex char code; e.g. `.` -> `-002e`). Decode it back so that
+      // workspaces on a remote host (WSL via \\wsl.localhost\, SSH-Remote)
+      // keep their authority when handed to `vscode.Uri.parse`. The
+      // catch-all replacement below strips the entire host, yielding a
+      // broken `file:///Ubuntu/...` URI whose fsPath has no UNC prefix and
+      // resolves to nothing on the local Windows filesystem.
       .replace(
-        /^https:\/\/file\+\.vscode-resource.vscode-cdn.net\//,
-        `${scheme}:///`,
+        /^https:\/\/file\+([^./]*)\.vscode-resource\.vscode-cdn\.net\//,
+        (_match, encodedAuthority: string) => {
+          const authority = encodedAuthority.replace(
+            /-([0-9a-f]{4})/gi,
+            (_m, hex: string) => String.fromCharCode(parseInt(hex, 16)),
+          );
+          return `${scheme}://${authority}/`;
+        },
       )
       .replace(/^https:\/\/.+\.vscode-cdn.net\//, `${scheme}:///`)
       .replace(


### PR DESCRIPTION
## Summary

Restore the ability to follow relative markdown links in the preview
when the workspace is opened over a remote authority — most visibly
WSL files accessed through `\\wsl.localhost\<distro>\...` from a
Windows host, and SSH-Remote workspaces.

Currently the link click silently does nothing (the URL after the
extension's regex rewrites points at a non-existent local Windows
path; depending on the user's drive layout VSCode may even open a
different file). After this fix the link opens the intended target.

## Reproduction

1. From a Windows host, open `\\wsl.localhost\Ubuntu\home\<user>\repo\README.md` in VSCode (do NOT use the Remote-WSL extension; just open the UNC path directly).
2. The README contains a relative markdown link, e.g. `[01 design](docs/zh/design/01-system-design.md)`.
3. Open the preview, click the link.
4. **Before this PR:** nothing happens (or a wrong file opens silently).
5. **After this PR:** the linked file opens.

The same file opened from a local Windows path works because the
workspace authority is empty.

## Root cause

The webview hands `clickTagA` URLs of the form

```
https://file+<encoded-authority>.vscode-resource.vscode-cdn.net/<path>
```

where `<encoded-authority>` is the source URI's authority with each
non-`[a-z0-9-]` character replaced by `-XXXX` (the 4-digit hex char
code). For `wsl.localhost` the encoded form is `wsl-002elocalhost`
(`.` -> `-002e`).

The existing chain of rewrites in `clickTagA`:

```ts
.replace(/^https:\/\/file\+\.vscode-resource.vscode-cdn.net\//, `${scheme}:///`)
.replace(/^https:\/\/.+\.vscode-cdn.net\//, `${scheme}:///`)
```

handles only the **empty-authority** case correctly. For non-empty
authority, the catch-all rule fires and strips the entire host along
with the encoded authority. The URL becomes

```
file:///Ubuntu/home/<user>/.../docs/zh/design/01-system-design.md
```

whose Windows `fsPath` is `\Ubuntu\home\<user>\...` (no UNC prefix),
so `vscode.workspace.fs.stat` resolves it relative to the current
drive root and the file is not found. Even worse, on some setups a
`\Ubuntu\...` path may exist and the click silently opens the wrong
file.

## Fix

Replace the empty-authority-only regex with a single rule that handles
both cases and decodes the encoded authority back into a real URI
authority:

```ts
.replace(
  /^https:\/\/file\+([^./]*)\.vscode-resource\.vscode-cdn\.net\//,
  (_match, encodedAuthority) => {
    const authority = encodedAuthority.replace(
      /-([0-9a-f]{4})/gi,
      (_m, hex) => String.fromCharCode(parseInt(hex, 16)),
    );
    return `${scheme}://${authority}/`;
  },
)
```

When the captured group is empty (workspace on the same host as
VSCode), the substitution reduces to `${scheme}:///`, exactly matching
the old behavior. When non-empty (WSL UNC, SSH-Remote), the URI is
rebuilt with the correct authority and `fs.stat` finds the real
target.

## Behavior matrix

| Workspace setup | Encoded host | Before | After |
|---|---|---|---|
| Local Windows / Linux / Mac | `file+.vscode-resource.vscode-cdn.net` | OK | unchanged |
| Windows + WSL UNC (`\\wsl.localhost\...`) | `file+wsl-002elocalhost.vscode-resource.vscode-cdn.net` | broken — `file:///Ubuntu/...` | fixed — `file://wsl.localhost/Ubuntu/...` |
| Windows + SSH-Remote workspace | `file+<encoded-host>.vscode-resource.vscode-cdn.net` | broken | fixed |
| Remote-WSL (`vscode-remote` scheme, extension runs in WSL server) | not affected — link URLs use `vscode-remote` scheme, not this codepath | unchanged | unchanged |

## Test plan

- [ ] On Windows: open a WSL repo via `\\wsl.localhost\<distro>\<path>\some.md` (no Remote-WSL). Preview, click a relative `[label](docs/foo.md)` link — verify it opens
- [ ] On Windows: open the same repo on a local Windows path. Preview, click the same link — verify it still opens (regression check)
- [ ] If you have SSH-Remote available: open a markdown file there from the host VSCode. Click a relative link in preview — verify it opens