### PR TITLE
0.8.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-06
+
+Updated [crossnote](https://github.com/shd101wyy/crossnote) to [0.9.30](https://github.com/shd101wyy/crossnote/releases/tag/0.9.30).
+
+### Security
+
+- **Fix a remote code execution vulnerability in `.crossnote/config.js` and `.crossnote/parser.js` evaluation**. These workspace files are now evaluated inside a [QuickJS](https://github.com/justjake/quickjs-emscripten) WebAssembly sandbox so untrusted code from a repository can no longer reach the host environment. Thanks to @ritikchaddha for reporting the issue.
+
+### Bug fixes
+
+- **Fix heading auto-ID generation for underscore-based italic/bold** — When a heading used underscore-based emphasis at the beginning or end (e.g., `_Toy Story_` or `__Bold Title__`), the generated heading ID would retain the underscores (e.g., `_toy-story_`), which markdown-it would interpret as emphasis markers, splitting the `{#id data-source-line="N"}` attribute block across multiple tokens and leaving it visible in the rendered output. Heading IDs now strip underscore emphasis markers following CommonMark rules — boundaries include punctuation (`# x _foo bar_! end` → `x-foo-bar-end`), adjacent runs both match (`_a_ _b_` → `a-b`), and intraword underscores are kept (`foo_bar_` → `foo_bar_`) — matching the anchors GitHub generates for the same headings. Additionally, ids embedded in the internal `{#id}` attribute block are now backslash-escaped so that any id still containing `_`/`*` survives inline parsing intact and rendered heading ids always match TOC anchors. Fixes [#2319](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2319). Reported by @skycommand.
+- **Fix `@import` / `![[wikilink]]` file resolution when the file path contains `#`** — When a project directory name contains `#` (e.g., `[#11111111]`), the `@import` and wikilink-based file imports would fail because the `#` in the directory name was incorrectly treated as a heading anchor fragment separator during post-resolution path splitting. The `#fragment` is now extracted from the original import syntax before path resolution, so literal `#` characters in directory paths are preserved (and `%23` can be used to write a literal `#` in import paths). Also fixed line-level `![[note^block-id]]` embeds (bare block reference without `#`), which previously failed to resolve the target block. Fixes [#2317](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2317). Reported by @LY1806620741.
+
 ## [0.8.28] - 2026-06-05
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to [0.9.29](https://github.com/shd101wyy/crossnote/releases/tag/0.9.29).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-preview-enhanced",
   "displayName": "%displayName%",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "description": "%description%",
   "categories": [
     "Other"
@@ -890,7 +890,7 @@
     "@types/crypto-js": "^4.1.2",
     "@types/vfile": "^3.0.2",
     "async-mutex": "^0.4.0",
-    "crossnote": "0.9.29",
+    "crossnote": "0.9.30",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,6 +453,18 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@jitl/quickjs-ffi-types@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz#43664daea79b1c42d69c262d80ebe743da25dc7d"
+  integrity sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==
+
+"@jitl/quickjs-singlefile-cjs-release-sync@^0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@jitl/quickjs-singlefile-cjs-release-sync/-/quickjs-singlefile-cjs-release-sync-0.32.0.tgz#69a2fc79f7f073ae20b123a68a632f9c0c976683"
+  integrity sha512-NjUUcw26PoeJHND6nmflAH8nIvAJvxJ2qkSPi95wfiBqPim80GtcdWommroiWb8hh1/7fVettEwodAsGt2Mrsg==
+  dependencies:
+    "@jitl/quickjs-ffi-types" "0.32.0"
+
 "@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
@@ -2534,13 +2546,14 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crossnote@0.9.29:
-  version "0.9.29"
-  resolved "https://registry.yarnpkg.com/crossnote/-/crossnote-0.9.29.tgz#18de19bfdcbf036df5caa709d3fe7e66ad48ff3c"
-  integrity sha512-HKTPPuisnRFk4Mip1W/tMn0ZxnXGGm9fqInIb+rUQeEqiB5udLstlf/5i7ksSdJN8qCw15DgCoJ6y5eMNil4Pw==
+crossnote@0.9.30:
+  version "0.9.30"
+  resolved "https://registry.yarnpkg.com/crossnote/-/crossnote-0.9.30.tgz#9a824c949b15cf91f4cb758354a9c0bac2489cb0"
+  integrity sha512-ulFKtHBMiUDXmLvr9MMfAM1GqXCbrKJx1kQFFQx+jjDzWiBgTke/dL9bnmdm0gBiDBGOqhnn7NYB8GlKWYS8hA==
   dependencies:
     "@headlessui/react" "^1.7.17"
     "@heroicons/react" "^2.0.18"
+    "@jitl/quickjs-singlefile-cjs-release-sync" "^0.32.0"
     "@mdi/js" "^7.2.96"
     "@mdi/react" "^1.6.1"
     "@monaco-editor/react" "^4.5.2"
@@ -2603,6 +2616,7 @@ crossnote@0.9.29:
     plantuml-encoder "^1.4.0"
     puppeteer-core "^24.16.2"
     qiniu "^7.9.0"
+    quickjs-emscripten-core "^0.32.0"
     react "^18.2.0"
     react-contexify "^6.0.0"
     react-dom "^18.2.0"
@@ -2610,7 +2624,6 @@ crossnote@0.9.29:
     sharp "^0.33.5"
     simple-icons "^9.13.0"
     slash "^5.1.0"
-    sval "^0.6.9"
     twemoji "^13.1.0"
     type-fest "^4.3.1"
     unstated-next "^1.1.0"
@@ -7228,6 +7241,13 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quickjs-emscripten-core@^0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz#a7b1c923fb57538c2ee543c70a6755df52533b3f"
+  integrity sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==
+  dependencies:
+    "@jitl/quickjs-ffi-types" "0.32.0"
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -8355,13 +8375,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-sval@^0.6.9:
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/sval/-/sval-0.6.9.tgz#a197b5c141bd6633ba677444481937f65572a56e"
-  integrity sha512-IZszs15QLaH+N79oRhczeucVLK4J8iUFRn3jgVwwHJylc5v0cxZDCX3fA/4uj8xxINpGpVgEojSi3DTNzyd8jA==
-  dependencies:
-    acorn "^8.14.0"
 
 sver-compat@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Updated [crossnote](https://github.com/shd101wyy/crossnote) to [0.9.30](https://github.com/shd101wyy/crossnote/releases/tag/0.9.30).

### Security

- **Fix a remote code execution vulnerability in `.crossnote/config.js` and `.crossnote/parser.js` evaluation**. These workspace files used to be evaluated with `vm.runInNewContext()` (desktop) and `sval` (web), neither of which is a security boundary — both share the host realm's object prototypes, so untrusted code could climb `({}).constructor.constructor` to reach the host `Function` constructor and, from there, `process` / `child_process`, achieving arbitrary command execution just by opening a Markdown file in a malicious repository. They are now evaluated inside a [QuickJS](https://github.com/justjake/quickjs-emscripten) WebAssembly sandbox so untrusted code from a repository can no longer reach the host environment. Thanks to @ritikchaddha for reporting the issue.

### Bug fixes

- **Fix heading auto-ID generation for underscore-based italic/bold** — Headings using underscore emphasis (e.g. `# _Toy Story_`, `# __Bold Title__`) produced IDs that retained the underscores, which markdown-it re-interpreted as emphasis and leaked the internal `{#id}` attribute block into the output. IDs now strip emphasis markers per CommonMark rules (matching GitHub's anchors) and the embedded `{#id}` block is escaped so rendered IDs always match TOC anchors. Fixes #2319. Reported by @skycommand.
- **Fix `@import` / `![[wikilink]]` file resolution when the file path contains `#`** — When a directory name contains `#` (e.g. `[#11111111]`), the `#` was mistaken for a heading-anchor fragment separator, breaking file resolution. The fragment is now extracted before path resolution. Also fixes line-level `![[note^block-id]]` embeds. Fixes #2317. Reported by @LY1806620741.

---

Bumps the extension to `0.8.29` and the bundled `crossnote` dependency to `0.9.30`. CHANGELOG updated accordingly.