### PR TITLE
build(nix): update nixpkgs to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776434932,
-        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
+        "lastModified": 1787848966,
+        "narHash": "sha256-7gDpu5hpq0rOYnYMcOWqSzquK4HA/xU8Xf3CjUBOOJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
+        "rev": "d57af924f160a5084293c71c2043f058bd1cdb60",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -58,11 +58,11 @@
     },
     "unstableNixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,8 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs = {
-      url = "github:NixOS/nixpkgs/nixos-25.11";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    unstableNixpkgs = {
-      url = "github:NixOS/nixpkgs/nixos-unstable";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    unstableNixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
@@ -29,7 +23,7 @@
         unstablePkgs = import unstableNixpkgs { inherit system; };
       in
       {
-        devShell = import ./shell.nix {
+        devShells.default = import ./shell.nix {
           inherit pkgs;
           inherit unstablePkgs;
         };


### PR DESCRIPTION
## Summary

Dev-environment only, no code impact.

- `nixpkgs`: `nixos-25.11` → `nixos-26.05` (rev `d57af924`, 2026-08-27 — the same rev the crossnote repo's flake now pins, so both dev shells share store paths).
- `unstableNixpkgs` refreshed to current unstable (rev `9fbb54b`, 2026-08-26).
- Dropped the self-referential `inputs.nixpkgs.follows = "nixpkgs"` overrides on both inputs — neither nixpkgs nor unstable has a sub-input named `nixpkgs`, so they only produced `override for a non-existent input` warnings.
- `devShell` output renamed to `devShells.<system>.default` (deprecated name).

## Test plan

- [x] `nix flake update` + `nix flake check` — dev shell evaluates on 26.05 (`nodejs_22`, `pnpm`, `vsce`, unstable `playwright.browsers` all resolve)
- [x] `pnpm install` / `pnpm check:all` / `pnpm build` / `pnpm test:unit` all green inside the updated shell