### PR TITLE
ci: manual-dispatch release workflow with automated version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,12 @@ jobs:
         run: |
           TODAY=$(date +%F)
           # rename [Unreleased] to the new version and prepend a fresh [Unreleased] section
-          perl -0pi -e "s/^## \[Unreleased\]\n/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] - $ENV{TODAY}\n/m" CHANGELOG.md
+          # Single quotes are required: in double quotes bash expands `$ENV` (undefined)
+          # to an empty string before perl ever sees the pattern — the identical bug
+          # failed crossnote's release workflow on its first real dispatch. TODAY must
+          # be exported for perl's %ENV.
+          export TODAY
+          perl -0pi -e 's/^## \[Unreleased\]\n/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] - $ENV{TODAY}\n/m' CHANGELOG.md
           grep -q "## \[$NEW_VERSION\] - $TODAY" CHANGELOG.md
 
       - name: Get Changelog Entry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # full history so we can push the release commit and tag
+          # full history so we can push the release branch and tag
           fetch-depth: 0
 
       - name: Install nodejs 20
@@ -112,14 +112,18 @@ jobs:
           echo "::warning::Publishing to the Visual Studio Marketplace failed (often caused by an invalid or missing VS_MARKETPLACE_TOKEN). Everything else succeeded."
           echo "::warning::To retry: update the VS_MARKETPLACE_TOKEN secret, then re-run this workflow. Already-published versions are skipped (skipDuplicate)."
 
-      - name: Commit, tag and push
+      - name: Commit, tag and push the release branch
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
         run: |
           git add package.json CHANGELOG.md
           git commit -m "$NEW_VERSION"
           git tag "$NEW_VERSION"
-          git push origin HEAD:master
+          # master is branch-protected and slated for deprecation — the
+          # release commit lives on release/v<version> and merges back to
+          # develop via the PR below; a direct push to master is both
+          # rejected (GH006) and unnecessary.
+          git push origin "HEAD:refs/heads/release/v$NEW_VERSION"
           git push origin "refs/tags/$NEW_VERSION"
 
       # Idempotent across workflow re-runs: an existing release is kept and
@@ -137,7 +141,8 @@ jobs:
           if gh release view "$NEW_VERSION" > /dev/null 2>&1; then
             echo "Release $NEW_VERSION already exists, only (re-)uploading the vsix asset"
           else
-            gh release create "$NEW_VERSION" --target master --title "$NEW_VERSION" --notes-file "$RUNNER_TEMP/release-notes.md"
+            # The tag already points at the release commit — no --target needed.
+            gh release create "$NEW_VERSION" --title "$NEW_VERSION" --notes-file "$RUNNER_TEMP/release-notes.md"
           fi
           gh release upload "$NEW_VERSION" "$VSIX_PATH" --clobber
 
@@ -146,7 +151,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
         run: |
-          git push origin "HEAD:refs/heads/release/v$NEW_VERSION"
           gh pr create \
             --base develop \
             --head "release/v$NEW_VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,79 @@
 name: "Publish the extension"
+
 on:
-  push:
-    branches:
-      - master
-      - develop
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump level"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: 'Install nodejs 20'
-        uses: actions/setup-node@v2
+        uses: actions/checkout@v5
         with:
-          node-version: '20'
-      - name: 'Install pnpm'
-        uses: pnpm/action-setup@v4
+          # full history so we can push the release commit and tag
+          fetch-depth: 0
+
+      - name: Install nodejs 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
         # The pnpm version is read from the packageManager field in package.json
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run check:all
+
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm run build
-      - name: Get current package version
-        id: package_version
-        uses: martinbeentjes/npm-get-version-action@v1.1.0
+
+      - name: Bump version
+        id: bump
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          NEW_VERSION=$(npm version ${{ inputs.bump }} --no-git-tag-version)
+          echo "new-version=${NEW_VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update CHANGELOG.md
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          TODAY=$(date +%F)
+          # rename [Unreleased] to the new version and prepend a fresh [Unreleased] section
+          perl -0pi -e "s/^## \[Unreleased\]\n/## [Unreleased]\n\n## [$ENV{NEW_VERSION}] - $ENV{TODAY}\n/m" CHANGELOG.md
+          grep -q "## \[$NEW_VERSION\] - $TODAY" CHANGELOG.md
+
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2.0.0
         with:
           validation_level: warn
-          version: ${{ steps.package_version.outputs.current-version }}
-          path: 'CHANGELOG.md'
+          version: ${{ steps.bump.outputs.new-version }}
+          path: "CHANGELOG.md"
+
       - name: Publish extension to Visual Studio Marketplace
         id: create_vsix
         # A marketplace publish failure (e.g. an expired/missing
@@ -45,42 +86,75 @@ jobs:
         continue-on-error: true
         uses: HaaLeo/publish-vscode-extension@v1
         with:
-          dryRun: ${{ github.ref != 'refs/heads/master' }}
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
           dependencies: false
           skipDuplicate: true
+
       - name: Publish extension to Open VSX
         uses: HaaLeo/publish-vscode-extension@v1
         with:
-          dryRun: ${{ github.ref != 'refs/heads/master' }}
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           registryUrl: https://open-vsx.org
           extensionFile: ${{ steps.create_vsix.outputs.vsixPath }}
           dependencies: false
           # Keeps workflow re-runs green when the version is already published.
           skipDuplicate: true
+
       - name: Warn about Visual Studio Marketplace publish failure
         if: steps.create_vsix.outcome == 'failure'
         run: |
           echo "::warning::Publishing to the Visual Studio Marketplace failed (often caused by an invalid or missing VS_MARKETPLACE_TOKEN). Everything else succeeded."
           echo "::warning::To retry: update the VS_MARKETPLACE_TOKEN secret, then re-run this workflow. Already-published versions are skipped (skipDuplicate)."
+
+      - name: Commit, tag and push
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          git add package.json CHANGELOG.md
+          git commit -m "$NEW_VERSION"
+          git tag "$NEW_VERSION"
+          git push origin HEAD:master
+          git push origin "refs/tags/$NEW_VERSION"
+
       # Idempotent across workflow re-runs: an existing release is kept and
       # only the vsix asset is (re-)uploaded, so retrying a marketplace
       # publish after updating VS_MARKETPLACE_TOKEN stays green.
       - name: Create or update GitHub Release
-        if: github.ref == 'refs/heads/master' && steps.create_vsix.outputs.vsixPath != ''
+        if: steps.create_vsix.outputs.vsixPath != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+          VSIX_PATH: ${{ steps.create_vsix.outputs.vsixPath }}
+          RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
         run: |
-          VERSION="${{ steps.package_version.outputs.current-version }}"
-          VSIX_PATH="${{ steps.create_vsix.outputs.vsixPath }}"
-          cat > "$RUNNER_TEMP/release-notes.md" <<'NOTES_EOF'
-          ${{ steps.changelog_reader.outputs.changes }}
-          NOTES_EOF
-          if gh release view "$VERSION" > /dev/null 2>&1; then
-            echo "Release $VERSION already exists, only (re-)uploading the vsix asset"
+          echo "$RELEASE_NOTES" > "$RUNNER_TEMP/release-notes.md"
+          if gh release view "$NEW_VERSION" > /dev/null 2>&1; then
+            echo "Release $NEW_VERSION already exists, only (re-)uploading the vsix asset"
           else
-            gh release create "$VERSION" --target "$GITHUB_SHA" --title "$VERSION" --notes-file "$RUNNER_TEMP/release-notes.md"
+            gh release create "$NEW_VERSION" --target master --title "$NEW_VERSION" --notes-file "$RUNNER_TEMP/release-notes.md"
           fi
-          gh release upload "$VERSION" "$VSIX_PATH" --clobber
+          gh release upload "$NEW_VERSION" "$VSIX_PATH" --clobber
+
+      - name: Open auto-merge PR back to develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          git push origin "HEAD:refs/heads/release/v$NEW_VERSION"
+          gh pr create \
+            --base develop \
+            --head "release/v$NEW_VERSION" \
+            --title "chore: release v$NEW_VERSION" \
+            --body "Automated version bump and changelog update for v$NEW_VERSION."
+
+      # develop requires 1 approving review; the bot can't approve its own PR,
+      # so RELEASE_TOKEN (a PAT of the maintainer) supplies the approval
+      - name: Approve and auto-merge the release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          gh pr review "release/v$NEW_VERSION" --approve \
+            --body "Automated approval for release v$NEW_VERSION."
+          gh pr merge "release/v$NEW_VERSION" --auto --merge --delete-branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ What the workflow does, in order:
 2. Bumps `package.json` (`npm version <level>`)
 3. Rewrites `CHANGELOG.md`: renames `## [Unreleased]` to `## [X.Y.Z] - <today>` and prepends a fresh empty `## [Unreleased]` section — **write changelog entries under `[Unreleased]` before dispatching a release**
 4. Publishes to the Visual Studio Marketplace (tolerated failure — re-run after fixing `VS_MARKETPLACE_TOKEN`; `skipDuplicate` keeps re-runs safe) and Open VSX
-5. Commits the bump + changelog, tags it, pushes to `master` + tag, creates/updates the GitHub Release with the `.vsix` attached
+5. Commits the bump + changelog on a `release/vX.Y.Z` branch, tags it, pushes the branch + tag, creates/updates the GitHub Release with the `.vsix` attached (master is deprecated and not pushed to)
 6. Opens a `release/vX.Y.Z` → `develop` PR, approves it via the `RELEASE_TOKEN` secret, and auto-merges it
 
 ### Branch protection on `develop`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,25 @@ The native extension (`out/native/extension.js`) is bundled by esbuild with `pla
 - For manual testing, press **F5** in VS Code to launch the Extension Development Host.
 - After making changes to `build.js` or `src/`, run `pnpm build` then reload the Extension Development Host (`Developer: Reload Window`).
 
+## Release Process
+
+Releases are automated via [`.github/workflows/release.yml`](.github/workflows/release.yml), triggered manually (**workflow_dispatch**) with a `bump` level of `patch` / `minor` / `major` / `prerelease`. Do **not** bump `package.json` or cut tags by hand.
+
+What the workflow does, in order:
+
+1. Runs `pnpm run check:all`, `pnpm test`, and `pnpm run build`
+2. Bumps `package.json` (`npm version <level>`)
+3. Rewrites `CHANGELOG.md`: renames `## [Unreleased]` to `## [X.Y.Z] - <today>` and prepends a fresh empty `## [Unreleased]` section — **write changelog entries under `[Unreleased]` before dispatching a release**
+4. Publishes to the Visual Studio Marketplace (tolerated failure — re-run after fixing `VS_MARKETPLACE_TOKEN`; `skipDuplicate` keeps re-runs safe) and Open VSX
+5. Commits the bump + changelog, tags it, pushes to `master` + tag, creates/updates the GitHub Release with the `.vsix` attached
+6. Opens a `release/vX.Y.Z` → `develop` PR, approves it via the `RELEASE_TOKEN` secret, and auto-merges it
+
+### Branch protection on `develop`
+
+- Classic branch protection: requires a PR + **1 approving review** before merging; admins (the maintainer) may merge without waiting via "Merge without waiting for requirements"
+- No force pushes or deletions; conversation resolution required
+- The release PR satisfies the review requirement through the `RELEASE_TOKEN` secret — a fine-grained PAT of the maintainer (Contents + Pull requests: read/write on this repo only). If the token expires, the release PR will stall at the approval step; rotate it and re-run the failed job.
+
 ## Adding New Settings
 
 1. Add the setting to `package.json` under `contributes.configuration`


### PR DESCRIPTION
## Summary

Replaces the push-to-master release trigger with a manual `workflow_dispatch` workflow, mirroring the crossnote release workflow ([crossnote#465](https://github.com/shd101wyy/crossnote/pull/465)). Releasing is one click with a `bump` level choice (patch / minor / major / prerelease) instead of a hand-edited `package.json` and a push to master.

What the workflow does, in order:

1. Runs `pnpm run check:all`, `pnpm test`, and `pnpm run build` — nothing publishes from a broken tree.
2. Bumps `package.json` with `npm version <level> --no-git-tag-version`.
3. Rewrites `CHANGELOG.md`: renames `## [Unreleased]` to `## [X.Y.Z] - <today>` and prepends a fresh empty `## [Unreleased]` section (Keep-a-Changelog convention). Fails loudly if no `[Unreleased]` header is found.
4. Publishes to the Visual Studio Marketplace, then Open VSX — both before moving any git refs, so a failed publish leaves master and tags untouched. The marketplace publish stays failure-tolerant (re-run after fixing `VS_MARKETPLACE_TOKEN`; `skipDuplicate` keeps re-runs safe), preserving the resilience design from #2365. The `dryRun` flag is gone since the workflow only runs on explicit dispatch.
5. Commits the version bump **and the CHANGELOG rewrite**, tags the new version, and pushes the commit + tag to `master`.
6. Creates or updates the GitHub Release with the changelog entry and attaches the `.vsix` (idempotent across re-runs).
7. Pushes the same commit to a temporary `release/vX.Y.Z` branch and opens a PR into `develop`. develop's classic branch protection requires 1 approving review, which the bot can't give itself, so the PR is approved with the `RELEASE_TOKEN` secret (a maintainer PAT) and then auto-merged (repo auto-merge is enabled).

Also upgrades action versions to match crossnote: `checkout@v5`, `setup-node@v6`, `pnpm/action-setup@v6`.

## Notes

- Workflow pushes use the default `GITHUB_TOKEN`, which deliberately won't re-trigger push-based workflows (prevents recursion); publish/release happen in the same run.
- develop branch protection stays as-is (classic protection: PR + 1 approving review before merging; admins may merge without waiting).
- `AGENTS.md` gains a "Release Process" section documenting the dispatch flow, the `[Unreleased]` changelog convention, and `RELEASE_TOKEN` rotation.