### PR TITLE
feat: enablePreviewContextMenu setting for context menu opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- **New setting `markdown-preview-enhanced.enablePreviewContextMenu`** (default `true`) — Disable it to turn off the custom right-click menu in the preview and fall back to the browser's native context menu with its usual Copy/Paste entries. Together with the companion crossnote change, the custom menu also gains a **Copy** item when text is selected and closes on **Escape**. Fixes [#2356](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2356) and [#2363](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2363). Reported by @andy-clapham and @miblooming. Requires the accompanying crossnote release; against crossnote 0.9.31 the setting has no effect.
+
 ## [0.8.30] - 2026-06-08
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to [0.9.31](https://github.com/shd101wyy/crossnote/releases/tag/0.9.31).

--- a/package.json
+++ b/package.json
@@ -785,6 +785,11 @@
           "default": false,
           "type": "boolean"
         },
+        "markdown-preview-enhanced.enablePreviewContextMenu": {
+          "description": "%markdown-preview-enhanced.enablePreviewContextMenu.description%",
+          "default": true,
+          "type": "boolean"
+        },
         "markdown-preview-enhanced.enableImageLightbox": {
           "description": "%markdown-preview-enhanced.enableImageLightbox.description%",
           "default": true,

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "Mostrar siempre los backlinks en la vista previa.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "Al activar esta opción se ocultarán los elementos de interfaz innecesarios en la vista previa, salvo cuando el ratón esté sobre ellos.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "Cuando está activado, el menú contextual de la vista previa hereda los colores y la fuente del tema de VS Code en lugar del estilo predeterminado.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "Muestra el menú contextual personalizado de la extensión en la vista previa. Desactívelo para volver al menú contextual nativo del navegador, con sus habituales entradas de copiar/pegar.",
   "markdown-preview-enhanced.enableImageLightbox.description": "Haga clic en una imagen de la vista previa para verla en una superposición de lightbox a pantalla completa. Pulse Escape o haga clic en el fondo para cerrar."
 }

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "Toujours afficher les rétroliens dans l'aperçu.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "Activer cette option masquera les éléments d'interface inutiles dans l'aperçu, sauf lorsque votre souris se trouve dessus.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "Lorsque cette option est activée, le menu contextuel de l'aperçu hérite des couleurs et de la police du thème de VS Code au lieu du style par défaut.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "Affiche le menu contextuel personnalisé de l'extension dans l'aperçu. Désactivez-le pour revenir au menu contextuel natif du navigateur, avec ses entrées copier/coller habituelles.",
   "markdown-preview-enhanced.enableImageLightbox.description": "Cliquez sur une image dans l'aperçu pour la voir dans une superposition lightbox en plein écran. Appuyez sur Échap ou cliquez sur l'arrière-plan pour fermer."
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "プレビューに常にバックリンクを表示します。",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "このオプションを有効にすると、マウスを乗せていない限り、プレビュー内の不要な UI 要素が非表示になります。",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "有効にすると、プレビュー内のコンテキストメニューが既定のスタイルではなく VS Code のテーマカラーとフォントを継承します。",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "プレビューに拡張機能のカスタム右クリックメニューを表示します。無効にすると、通常のコピー/貼り付けなどの項目を備えたブラウザー標準の右クリックメニューに戻ります。",
   "markdown-preview-enhanced.enableImageLightbox.description": "プレビュー内の画像をクリックすると、全画面のライトボックスオーバーレイで表示できます。Escape を押すか背景をクリックすると閉じます。"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "Always show backlinks in preview.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "Enable this option will hide unnecessary UI elements in preview unless your mouse is over it.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "When enabled, the context menu in preview inherits VS Code's theme colors and font instead of the default styling.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "Show the extension's custom right-click menu in the preview. Disable it to fall back to the browser's native context menu, with its usual Copy/Paste entries.",
   "markdown-preview-enhanced.enableImageLightbox.description": "Click an image in the preview to view it in a full-screen lightbox overlay. Press Escape or click the backdrop to close."
 }

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "미리 보기에 항상 백링크를 표시합니다.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "이 옵션을 활성화하면 마우스를 올려놓지 않는 한 미리 보기의 불필요한 UI 요소가 숨겨집니다.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "활성화하면 미리 보기의 컨텍스트 메뉴가 기본 스타일 대신 VS Code의 테마 색상과 글꼴을 상속합니다.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "미리보기에 확장의 사용자 지정 마우스 오른쪽 클릭 메뉴를 표시합니다. 비활성화하면 일반적인 복사/붙여넣기 항목이 있는 브라우저 기본 마우스 오른쪽 클릭 메뉴로 되돌아갑니다.",
   "markdown-preview-enhanced.enableImageLightbox.description": "미리 보기의 이미지를 클릭하면 전체 화면 라이트박스 오버레이에서 볼 수 있습니다. Escape를 누르거나 배경을 클릭하면 닫힙니다."
 }

--- a/package.nls.nl.json
+++ b/package.nls.nl.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "Altijd backlinks tonen in het voorbeeld.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "Door deze optie in te schakelen worden onnodige UI-elementen in het voorbeeld verborgen, tenzij uw muis erboven zweeft.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "Indien ingeschakeld neemt het contextmenu in het voorbeeld de themakleuren en het lettertype van VS Code over in plaats van de standaardstijl.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "Toont het aangepaste rechtermuisknopmenu van de extensie in de preview. Schakel het uit om terug te vallen op het native browsermenu, met de gebruikelijke kopiëren/plakken-opties.",
   "markdown-preview-enhanced.enableImageLightbox.description": "Klik op een afbeelding in het voorbeeld om deze te bekijken in een schermvullende lightbox-overlay. Druk op Escape of klik op de achtergrond om te sluiten."
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "Sempre mostrar backlinks na visualização.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "Ativar esta opção ocultará elementos de interface desnecessários na visualização, a menos que o mouse esteja sobre eles.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "Quando ativado, o menu de contexto na visualização herda as cores e a fonte do tema do VS Code em vez do estilo padrão.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "Mostra o menu de contexto personalizado da extensão na pré-visualização. Desative-o para voltar ao menu de contexto nativo do navegador, com as entradas usuais de copiar/colar.",
   "markdown-preview-enhanced.enableImageLightbox.description": "Clique em uma imagem na visualização para vê-la em uma sobreposição de lightbox em tela cheia. Pressione Esc ou clique no fundo para fechar."
 }

--- a/package.nls.tr.json
+++ b/package.nls.tr.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "Önizlemede geri bağlantıları her zaman göster.",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "Bu seçeneğin etkinleştirilmesi, fareniz üzerinde olmadığı sürece önizlemedeki gereksiz arayüz öğelerini gizler.",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "Etkinleştirildiğinde, önizlemedeki bağlam menüsü varsayılan stil yerine VS Code'un tema renklerini ve yazı tipini devralır.",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "Önizlemede uzantının özel sağ tık menüsünü gösterir. Devre dışı bırakınca, alışıldık kopyala/yapıştır girdileriyle birlikte tarayıcının yerel sağ tık menüsüne dönülür.",
   "markdown-preview-enhanced.enableImageLightbox.description": "Önizlemedeki bir görüntüye tıklayarak tam ekran lightbox katmanında görüntüleyin. Kapatmak için Escape tuşuna basın veya arka plana tıklayın."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "始终在预览中显示反向链接。",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "启用此选项将隐藏预览中不必要的 UI 元素，除非鼠标悬停其上。",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "启用后，预览中的右键菜单将继承 VS Code 的主题颜色和字体，而非默认样式。",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "在预览中显示扩展的自定义右键菜单。关闭后将回退到浏览器原生右键菜单，保留惯用的复制/粘贴等条目。",
   "markdown-preview-enhanced.enableImageLightbox.description": "点击预览中的图片可在全屏灯箱叠层中查看。按 Escape 或点击背景关闭。"
 }

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -125,5 +125,6 @@
   "markdown-preview-enhanced.alwaysShowBacklinksInPreview.description": "一律在預覽中顯示反向連結。",
   "markdown-preview-enhanced.enablePreviewZenMode.description": "啟用此選項將隱藏預覽中不必要的 UI 元素，除非滑鼠停留其上。",
   "markdown-preview-enhanced.useVSCodeThemeForContextMenu.description": "啟用後，預覽中的右鍵選單將繼承 VS Code 的主題顏色和字型，而非預設樣式。",
+  "markdown-preview-enhanced.enablePreviewContextMenu.description": "在預覽中顯示擴充功能的自訂右鍵選單。關閉後將回退到瀏覽器原生右鍵選單，保留慣用的複製/貼上等項目。",
   "markdown-preview-enhanced.enableImageLightbox.description": "點擊預覽中的圖片可在全螢幕燈箱疊層中檢視。按 Escape 或點擊背景關閉。"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ type VSCodeMPEConfigKey =
   | 'automaticallyShowPreviewOfMarkdownBeingEdited'
   | 'configPath'
   | 'enableImageLightbox'
+  | 'enablePreviewContextMenu'
   | 'imageUploader'
   | 'hideDefaultVSCodeMarkdownPreviewButtons'
   | 'liveUpdate'
@@ -110,6 +111,12 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
   public readonly alwaysShowBacklinksInPreview: boolean;
   public readonly enablePreviewZenMode: boolean;
   public readonly useVSCodeThemeForContextMenu: boolean;
+  /**
+   * Whether to show the custom context menu in the preview. Part of
+   * crossnote's `NotebookConfig` (read by the webview); against
+   * crossnote versions that predate the field the value is ignored.
+   */
+  public readonly enablePreviewContextMenu: boolean;
   public readonly wikiLinkTargetFileExtension: string;
   public readonly wikiLinkTargetFileNameChangeCase: WikiLinkTargetFileNameChangeCase;
   public readonly wikiLinkResolution: WikiLinkResolution;
@@ -295,6 +302,8 @@ export class MarkdownPreviewEnhancedConfig implements NotebookConfig {
     this.useVSCodeThemeForContextMenu =
       getMPEConfig<boolean>('useVSCodeThemeForContextMenu') ??
       defaultConfig.useVSCodeThemeForContextMenu;
+    this.enablePreviewContextMenu =
+      getMPEConfig<boolean>('enablePreviewContextMenu') ?? true;
     this.wikiLinkTargetFileExtension =
       getMPEConfig<string>('wikiLinkTargetFileExtension') ??
       defaultConfig.wikiLinkTargetFileExtension;


### PR DESCRIPTION
## Summary

Extension side of the context-menu work for [#2356](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2356) and [#2363](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2363):

- New setting **`markdown-preview-enhanced.enablePreviewContextMenu`** (default `true`). Disable it to turn off the preview's custom right-click menu and get the **browser's native context menu** back — with its usual Copy/Paste entries — per #2356's "just a preview" request. Descriptions added for all 10 locales.
- Wired in `config.ts` and fed to crossnote's `enablePreviewContextMenu` config field, which the webview reads.

The behavior itself lives in the companion crossnote PR shd101wyy/crossnote#474, which also adds a **Copy** item to the custom menu when text is selected (#2363) and makes **Escape** close it. Against crossnote 0.9.31 this setting is inert (the field is simply ignored downstream), so this PR can merge before or after the crossnote release + dependency bump.

## Test plan

- [x] `pnpm check:all` (eslint + prettier) green, `tsc --noEmit` green
- [x] `pnpm build` produces native + web bundles
- [x] `pnpm test:unit` — 58 passing
- [ ] Manual F5 run against a local crossnote build once crossnote#474 lands