### PR TITLE
fix: contain note indexing to the notebook root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Stop the note index from scanning outside the workspace** — when the resolved notebook root was the filesystem root itself (VS Code opened on `/` or a Windows drive root, a standalone Markdown file directly under it, or an untitled document whose fallback root `/.` resolves to `/`), building the wikilink/backlink/tag/graph index recursively stat'ed and read files across the whole machine; a symbolic link inside the workspace could similarly let the walk escape it. crossnote now refuses to index a filesystem-root notebook and never follows symbolic links during the walk (link entries are not indexed), and permission errors (`EACCES`/`EPERM`) encountered while walking are no longer logged as errors per directory. The extension shows a one-time warning when the notebook root is a filesystem root, since wikilinks/backlinks/graph will find nothing until a real folder is opened ([#2376](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2376) reported by @prawnsalad).
+
 ## [0.8.32] - 2026-08-31
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to [0.9.32](https://github.com/shd101wyy/crossnote/releases/tag/0.9.32).

--- a/src/notebooks-manager.ts
+++ b/src/notebooks-manager.ts
@@ -5,6 +5,7 @@ import {
   PreviewTheme,
   loadConfigsInDirectory,
 } from 'crossnote';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import {
   MarkdownPreviewEnhancedConfig,
@@ -29,12 +30,20 @@ class NotebooksManager {
 
   private failedNotebookPaths: Set<string> = new Set();
 
+  /**
+   * Notebook roots that were already reported to the user as filesystem
+   * roots (see `warnIfFilesystemRoot`), so the warning shows once per
+   * root per session instead of once per `getNotebook` call.
+   */
+  private filesystemRootWarnedPaths: Set<string> = new Set();
+
   constructor(private context: vscode.ExtensionContext) {
     this.fileWatcher = new FileWatcher(this.context, this);
   }
 
   public async getNotebook(uri: vscode.Uri): Promise<Notebook> {
     const workspaceFolderUri = getWorkspaceFolderUri(uri);
+    this.warnIfFilesystemRoot(workspaceFolderUri);
 
     // Check if workspaceUri already exists in this.notebooks
     for (let i = 0; i < this.notebooks.length; i++) {
@@ -72,6 +81,29 @@ class NotebooksManager {
     this.applyPreviewScripts(notebook);
     notebook.updateConfig(await this.loadNotebookConfig(uri));
     return notebook;
+  }
+
+  /**
+   * A notebook rooted at a filesystem root (`/`, a Windows drive root,
+   * or dot-path spellings of it like `/.` — the untitled-document
+   * fallback) would recursively stat/read files across the whole
+   * machine when the wikilink/backlink/graph index is built (#2376).
+   * crossnote refuses to walk such a root; this surfaces that to the
+   * user once per root so the empty backlinks/graph aren't a mystery.
+   */
+  private warnIfFilesystemRoot(workspaceFolderUri: vscode.Uri) {
+    const resolved = path.resolve(workspaceFolderUri.fsPath);
+    if (path.parse(resolved).root !== resolved) {
+      return;
+    }
+    const key = workspaceFolderUri.toString();
+    if (this.filesystemRootWarnedPaths.has(key)) {
+      return;
+    }
+    this.filesystemRootWarnedPaths.add(key);
+    void vscode.window.showWarningMessage(
+      `Markdown Preview Enhanced: the notebook root "${workspaceFolderUri.fsPath}" is a filesystem root, so notes are not indexed (wikilinks, backlinks, tags and the graph view will find nothing). Open a specific folder as your workspace to enable note indexing.`,
+    );
   }
 
   public async updateNotebookConfig(

--- a/src/vscode-fs.ts
+++ b/src/vscode-fs.ts
@@ -60,10 +60,14 @@ export function wrapVSCodeFSAsApi(
     stat: async (path: string): Promise<FileSystemStats> => {
       const uri = getUri(path, scheme, authority);
       const stat = await vscode.workspace.fs.stat(uri);
+      // FileType bits are OR-ed together (a symlink to a directory is
+      // `Directory | SymbolicLink`), so test bits — not equality.
+      const hasType = (...types: vscode.FileType[]) =>
+        types.some((type) => (stat.type & type) !== 0);
       return {
-        isDirectory: () => stat.type === vscode.FileType.Directory,
-        isFile: () => stat.type === vscode.FileType.File,
-        isSymbolicLink: () => stat.type === vscode.FileType.SymbolicLink,
+        isDirectory: () => hasType(vscode.FileType.Directory),
+        isFile: () => hasType(vscode.FileType.File),
+        isSymbolicLink: () => hasType(vscode.FileType.SymbolicLink),
         size: stat.size,
         mtimeMs: stat.mtime,
         ctimeMs: stat.ctime,


### PR DESCRIPTION
## What

Fixes #2376, where the extension was found scanning every private and system folder outside the workspace (1221 `EACCES`/`EPERM` log entries across `/Users`, `/Library`, `/System`, `/private/var`, `/Volumes`, … on macOS).

## Root cause

The note-index walk (wikilinks, backlinks, tags, graph view) recursively walks the **resolved notebook root**. When that root is the filesystem root itself, it stat'ed and read markdown files across the whole machine. That happens when:

- the workspace folder is `/` (or a Windows drive root),
- a standalone markdown file sits directly under `/` (`getWorkspaceFolderUri` falls back to `path.dirname`),
- or the document is **untitled**: the fallback `path.dirname('Untitled-1') === '.'` → `Uri.file('.')` → fsPath `/.`, which `path.resolve`s to `/` — and this needs no user action beyond typing in an untitled markdown buffer (completion providers trigger the index build).

## Changes here

- **One-time user warning** when the notebook root is a filesystem root (`NotebooksManager.getNotebook`), since indexing is refused and wikilinks/backlinks/graph will find nothing until a real folder is opened.
- **`vscode-fs.ts` stat adapter: test `FileType` bits, not equality** — VS Code reports a symlink to a directory as `Directory | SymbolicLink`, so the old `===` checks made `isFile()` false for symlinked files and `isSymbolicLink()` false for symlinked dirs. The walk's symlink containment (in crossnote) relies on those bits.

## Companion crossnote PR

The walk refusal itself lives in crossnote — [shd101wyy/crossnote#483](https://github.com/shd101wyy/crossnote/pull/483) (refuse filesystem-root notebooks; never follow symlinks in the walk; stop `console.error`-ing every denied directory, which is what made the scan visible as 1000+ error entries). This PR compiles and passes CI against published crossnote 0.9.32 (no API changes are consumed); the runtime guard ships when crossnote is released and the dependency pin is bumped.