### PR TITLE
docs: changelog for the callout preview crash fix (#2375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Stop the note index from scanning outside the workspace** — when the resolved notebook root was the filesystem root itself (VS Code opened on `/` or a Windows drive root, a standalone Markdown file directly under it, or an untitled document whose fallback root `/.` resolves to `/`), building the wikilink/backlink/tag/graph index recursively stat'ed and read files across the whole machine; a symbolic link inside the workspace could similarly let the walk escape it. crossnote now refuses to index a filesystem-root notebook and never follows symbolic links during the walk (link entries are not indexed), and permission errors (`EACCES`/`EPERM`) encountered while walking are no longer logged as errors per directory. The extension shows a one-time warning when the notebook root is a filesystem root, since wikilinks/backlinks/graph will find nothing until a real folder is opened ([#2376](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2376) reported by @prawnsalad).
 
+### Bug fixes
+
+- **Fix preview crash (`TypeError: Cannot read properties of null (reading 'length')`) on callouts with a blank line under the marker** — an Obsidian-style callout whose `[!NOTE]` marker line stands alone or is followed by a blank quoted line crashed the entire preview; 0.8.32 introduced it via a crossnote callout change. Fixed in crossnote; ships when crossnote is released and the dependency pin is bumped ([#2375](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2375) reported by @GodExious).
+
 ## [0.8.32] - 2026-08-31
 
 Updated [crossnote](https://github.com/shd101wyy/crossnote) to [0.9.32](https://github.com/shd101wyy/crossnote/releases/tag/0.9.32).


### PR DESCRIPTION
Changelog entry for [#2375](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2375): the preview crashed with `TypeError: Cannot read properties of null (reading 'length')` on any callout whose `[!NOTE]` marker line stands alone or is followed by a blank quoted line (regression in 0.8.32). The fix itself is in [shd101wyy/crossnote#485](https://github.com/shd101wyy/crossnote/pull/485) and ships when crossnote is released and the dependency pin is bumped — no extension source changes needed.