### PR TITLE
feat: add commands to copy the focused preview's source path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- **New commands "Copy Current Source Path" and "Copy Current Source Relative Path"** — Copy the Markdown file that the focused preview is actually rendering, as a full filesystem path/URI or as a workspace-relative path. Following a link inside the preview leaves the preview and the editor resource it was opened from out of sync (the drift behind the stale breadcrumb in [#2235](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2235)), so VS Code's built-in **Copy Path** / **Copy Relative Path** can copy a different file than the one on screen — most visibly with `"markdown-preview-enhanced.previewMode": "Previews Only"`, where the preview is the tab and no text editor is open. The commands read the source of the focused preview panel only and never guess: with no preview focused, with two previews active, or before a preview has rendered, they warn instead of copying, as does asking for a relative path outside the workspace. `file:` sources are copied as filesystem paths (Windows drive letters and UNC spellings preserved), while remote and virtual sources keep their scheme and authority.
+
 ## [0.8.33] - 2026-09-02
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "run-in-browser:watch": "node build.js --web-dev && concurrently \"vscode-test-web --browser none --extensionDevelopmentPath=. ${SERVE_DIR:-.}\" \"npx http-server ./crossnote -p 6789 --cors\" \"node build.js --watch\"",
     "run-in-vscode-dev": "npx serve --cors -l 5000 --ssl-cert $HOME/certs/localhost.pem --ssl-key $HOME/certs/localhost-key.pem",
     "test": "pnpm test:unit",
-    "test:unit": "mocha --ui tdd --reporter spec test/find-fragment-target-line.test.js test/block-id-helpers.test.js test/rank-by-closeness.test.js",
+    "test:unit": "mocha --ui tdd --reporter spec test/find-fragment-target-line.test.js test/block-id-helpers.test.js test/rank-by-closeness.test.js test/current-preview-source.test.js test/preview-source-integration.test.js",
     "vscode:prepublish": "pnpm install --frozen-lockfile && pnpm build",
     "watch": "gulp copy-files && gulp clean-out && node build.js --watch"
   },
@@ -79,6 +79,16 @@
       {
         "command": "markdown-preview-enhanced.copyBlockReference",
         "title": "%markdown-preview-enhanced.copyBlockReference.title%",
+        "category": "Markdown"
+      },
+      {
+        "command": "markdown-preview-enhanced.copyCurrentSourceRelativePath",
+        "title": "%markdown-preview-enhanced.copyCurrentSourceRelativePath.title%",
+        "category": "Markdown"
+      },
+      {
+        "command": "markdown-preview-enhanced.copyCurrentSourcePath",
+        "title": "%markdown-preview-enhanced.copyCurrentSourcePath.title%",
         "category": "Markdown"
       },
       {

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:Abrir vista previa bloqueada lateral",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:Alternar bloqueo de vista previa",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:Copiar referencia de bloque",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:Copiar ruta relativa de la fuente actual",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:Copiar ruta de la fuente actual",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:Alternar sincronización de desplazamiento",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:Alternar actualización en vivo",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:Alternar salto de línea",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:Ouvrir l'aperçu verrouillé sur le côté",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:Basculer le verrouillage de l'aperçu",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:Copier la référence de bloc",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:Copier le chemin relatif de la source actuelle",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:Copier le chemin de la source actuelle",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:Basculer la synchronisation du défilement",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:Basculer la mise à jour en direct",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:Basculer le saut de ligne",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:ロックされたプレビューを横に開く",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:プレビューロックの切り替え",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:ブロック参照をコピー",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:現在のソースの相対パスをコピー",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:現在のソースパスをコピー",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:スクロール同期の切り替え",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:ライブ更新の切り替え",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:改行の切り替え",

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "Markdown Preview Enhanced: Open Locked Preview to the Side",
   "markdown-preview-enhanced.togglePreviewLock.title": "Markdown Preview Enhanced: Toggle Preview Lock",
   "markdown-preview-enhanced.copyBlockReference.title": "Markdown Preview Enhanced: Copy Block Reference",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "Markdown Preview Enhanced: Copy Current Source Relative Path",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "Markdown Preview Enhanced: Copy Current Source Path",
   "markdown-preview-enhanced.toggleScrollSync.title": "Markdown Preview Enhanced: Toggle Scroll Sync",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "Markdown Preview Enhanced: Toggle Live Update",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "Markdown Preview Enhanced: Toggle Break On Single New Line",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:잠긴 미리보기를 옆에 열기",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:미리보기 잠금 전환",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:블록 참조 복사",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:현재 소스 상대 경로 복사",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:현재 소스 경로 복사",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:스크롤 동기화 전환",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:실시간 업데이트 전환",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:줄바꿈 전환",

--- a/package.nls.nl.json
+++ b/package.nls.nl.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:Vergrendeld voorbeeld naast openen",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:Voorbeeldvergrendeling schakelen",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:Blokverwijzing kopiëren",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:Relatief pad van huidige bron kopiëren",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:Pad van huidige bron kopiëren",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:Scrollsynchronisatie schakelen",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:Live update schakelen",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:Regeleinde schakelen",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:Abrir visualização bloqueada lateral",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:Alternar bloqueio da visualização",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:Copiar referência de bloco",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:Copiar caminho relativo da fonte atual",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:Copiar caminho da fonte atual",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:Alternar sincronização de rolagem",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:Alternar atualização ao vivo",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:Alternar quebra de linha",

--- a/package.nls.tr.json
+++ b/package.nls.tr.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:Kilitli önizlemeyi yanda aç",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:Önizleme kilidini değiştir",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:Blok referansını kopyala",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:Geçerli kaynağın göreli yolunu kopyala",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:Geçerli kaynağın yolunu kopyala",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:Kaydırma senkronizasyonunu değiştir",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:Canlı güncellemeyi değiştir",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:Satır sonu davranışını değiştir",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:打开锁定的侧边预览",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:切换预览锁定",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:复制块引用",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:复制当前源的相对路径",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:复制当前源路径",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:开关预览滑动同步",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:开关预览实时更新",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:开关回车换行",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -8,6 +8,8 @@
   "markdown-preview-enhanced.openLockedPreviewToTheSide.title": "MPE:開啟鎖定的側邊預覽",
   "markdown-preview-enhanced.togglePreviewLock.title": "MPE:切換預覽鎖定",
   "markdown-preview-enhanced.copyBlockReference.title": "MPE:複製區塊引用",
+  "markdown-preview-enhanced.copyCurrentSourceRelativePath.title": "MPE:複製目前來源的相對路徑",
+  "markdown-preview-enhanced.copyCurrentSourcePath.title": "MPE:複製目前來源路徑",
   "markdown-preview-enhanced.toggleScrollSync.title": "MPE:開關預覽捲動同步",
   "markdown-preview-enhanced.toggleLiveUpdate.title": "MPE:開關預覽即時更新",
   "markdown-preview-enhanced.toggleBreakOnSingleNewLine.title": "MPE:開關換行符換行",

--- a/src/current-preview-source.ts
+++ b/src/current-preview-source.ts
@@ -1,0 +1,51 @@
+export interface PreviewSourceState<TSource> {
+  readonly active: boolean;
+  readonly sourceUri: TSource | undefined;
+}
+
+export interface SourceUriLike {
+  readonly scheme: string;
+  readonly fsPath: string;
+  with(change: { query?: string; fragment?: string }): SourceUriLike;
+  toString(): string;
+}
+
+/**
+ * Return the source for the only focused preview.
+ *
+ * Multiple active previews are treated as ambiguous instead of guessing which
+ * one the user intended. An active preview without a rendered source is also
+ * unresolved.
+ */
+export function resolveActivePreviewSource<TSource>(
+  states: Iterable<PreviewSourceState<TSource>>,
+): TSource | undefined {
+  let activeState: PreviewSourceState<TSource> | undefined;
+
+  for (const state of states) {
+    if (!state.active) {
+      continue;
+    }
+    if (activeState) {
+      return undefined;
+    }
+    activeState = state;
+  }
+
+  return activeState?.sourceUri;
+}
+
+/**
+ * Format a source URI without treating remote or virtual resources as local
+ * filesystem paths.
+ *
+ * The query and fragment are dropped so that a link followed inside the
+ * preview yields the source resource itself, matching what `fsPath` returns
+ * for `file:` URIs.
+ */
+export function formatPreviewSourcePath(sourceUri: SourceUriLike): string {
+  if (sourceUri.scheme === 'file') {
+    return sourceUri.fsPath;
+  }
+  return sourceUri.with({ query: '', fragment: '' }).toString();
+}

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -262,7 +262,7 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
       return;
     }
 
-    const relativePath = vscode.workspace.asRelativePath(sourceUri, false);
+    const relativePath = vscode.workspace.asRelativePath(sourceUri);
     await vscode.env.clipboard.writeText(relativePath);
     vscode.window.showInformationMessage(
       `Copied relative source path: ${relativePath}`,

--- a/src/extension-common.ts
+++ b/src/extension-common.ts
@@ -10,12 +10,17 @@ import {
   openWikilinkTarget,
 } from './wikilink-document-link-provider';
 import { PreviewColorScheme, getMPEConfig, updateMPEConfig } from './config';
+import { formatPreviewSourcePath } from './current-preview-source';
 import { customEditorProviderOptions } from './custom-editor-options';
 import { findFragmentTargetLine } from './find-fragment-target-line';
 import { pasteImageFile, uploadImageFile } from './image-helper';
 import NotebooksManager from './notebooks-manager';
 import { PreviewCustomEditorProvider } from './preview-custom-editor-provider';
-import { PreviewProvider, getPreviewUri } from './preview-provider';
+import {
+  PreviewProvider,
+  getActivePreviewSourceUri,
+  getPreviewUri,
+} from './preview-provider';
 import { GraphViewProvider } from './graph-view-provider';
 import {
   createMissingMarkdownNote,
@@ -228,6 +233,51 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
     const ref = `[[${noteName}#^${blockId}]]`;
     await vscode.env.clipboard.writeText(ref);
     vscode.window.showInformationMessage(`Copied block reference: ${ref}`);
+  }
+
+  /**
+   * Resolve the source of the focused preview, warning the user when it cannot
+   * be determined.
+   */
+  function resolveCurrentPreviewSourceOrWarn(): vscode.Uri | undefined {
+    const sourceUri = getActivePreviewSourceUri();
+    if (!sourceUri) {
+      vscode.window.showWarningMessage(
+        'Focus the Markdown Preview Enhanced preview whose source you want to copy, then run this command again.',
+      );
+      return undefined;
+    }
+    return sourceUri;
+  }
+
+  async function copyCurrentSourceRelativePath() {
+    const sourceUri = resolveCurrentPreviewSourceOrWarn();
+    if (!sourceUri) {
+      return;
+    }
+    if (!vscode.workspace.getWorkspaceFolder(sourceUri)) {
+      vscode.window.showWarningMessage(
+        'The source of the focused Markdown preview is outside the workspace, so it has no workspace-relative path.',
+      );
+      return;
+    }
+
+    const relativePath = vscode.workspace.asRelativePath(sourceUri, false);
+    await vscode.env.clipboard.writeText(relativePath);
+    vscode.window.showInformationMessage(
+      `Copied relative source path: ${relativePath}`,
+    );
+  }
+
+  async function copyCurrentSourcePath() {
+    const sourceUri = resolveCurrentPreviewSourceOrWarn();
+    if (!sourceUri) {
+      return;
+    }
+
+    const sourcePath = formatPreviewSourcePath(sourceUri);
+    await vscode.env.clipboard.writeText(sourcePath);
+    vscode.window.showInformationMessage(`Copied source path: ${sourcePath}`);
   }
 
   function generateUniqueBlockId(text: string): string {
@@ -1318,6 +1368,17 @@ export async function initExtensionCommon(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'markdown-preview-enhanced.togglePreviewLock',
       togglePreviewLock,
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'markdown-preview-enhanced.copyCurrentSourceRelativePath',
+      copyCurrentSourceRelativePath,
+    ),
+    vscode.commands.registerCommand(
+      'markdown-preview-enhanced.copyCurrentSourcePath',
+      copyCurrentSourcePath,
     ),
   );
 

--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -10,6 +10,10 @@ import {
   setBlockTranslation,
 } from './ai-translation-cache';
 import { getMPEConfig } from './config';
+import {
+  PreviewSourceState,
+  resolveActivePreviewSource,
+} from './current-preview-source';
 import { hashBlock, splitMarkdownBlocks } from './markdown-blocks';
 import NotebooksManager from './notebooks-manager';
 import {
@@ -169,6 +173,14 @@ export function getAllPreviewProviders(): PreviewProvider[] {
   return Array.from(WORKSPACE_PREVIEW_PROVIDER_MAP.values());
 }
 
+export function getActivePreviewSourceUri(): vscode.Uri | undefined {
+  return resolveActivePreviewSource(
+    getAllPreviewProviders().flatMap((provider) =>
+      provider.getPreviewSourceStates(),
+    ),
+  );
+}
+
 // http://www.typescriptlang.org/play/
 // https://github.com/Microsoft/vscode/blob/master/extensions/markdown/media/main.js
 // https://github.com/Microsoft/vscode/tree/master/extensions/markdown/src
@@ -249,6 +261,9 @@ export class PreviewProvider {
    */
   private previewMaps: Map<string, Set<vscode.WebviewPanel>> = new Map();
   private previewToDocumentMap: Map<vscode.WebviewPanel, vscode.TextDocument> =
+    new Map();
+  /** The source URI whose HTML is currently installed in each preview. */
+  private previewToSourceUriMap: Map<vscode.WebviewPanel, vscode.Uri> =
     new Map();
   private initializedPreviews: Set<vscode.WebviewPanel> = new Set();
 
@@ -426,12 +441,20 @@ export class PreviewProvider {
     }
   }
 
+  public getPreviewSourceStates(): PreviewSourceState<vscode.Uri>[] {
+    return Array.from(this.initializedPreviews, (previewPanel) => ({
+      active: previewPanel.active,
+      sourceUri: this.previewToSourceUriMap.get(previewPanel),
+    }));
+  }
+
   public destroyPreview(sourceUri: Uri) {
     const previewMode = getPreviewMode();
     if (previewMode === PreviewMode.SinglePreview) {
       PreviewProvider.singlePreviewPanel = null;
       PreviewProvider.singlePreviewPanelSourceUriTarget = null;
       this.previewToDocumentMap = new Map();
+      this.previewToSourceUriMap = new Map();
       this.previewMaps = new Map();
       this.latestRenderRequestBySourceUri.clear();
     } else {
@@ -602,6 +625,7 @@ export class PreviewProvider {
         previewPanel.onDidDispose(
           () => {
             PreviewProvider.singlePreviewLocked = false;
+            this.previewToSourceUriMap.delete(previewPanel);
             this.destroyPreview(sourceUri);
             this.destroyEngine(sourceUri);
             this.initializedPreviews.delete(previewPanel);
@@ -704,6 +728,10 @@ export class PreviewProvider {
         return;
       }
       previewPanel.webview.html = html;
+      // Publish the source only after this render won the request race and its
+      // HTML was installed. Until then, the panel still represents its prior
+      // source (or has no reliably rendered source yet).
+      this.previewToSourceUriMap.set(previewPanel, sourceUri);
     } catch (error) {
       vscode.window.showErrorMessage(String(error));
       console.error(error);
@@ -729,6 +757,7 @@ export class PreviewProvider {
 
     this.previewMaps = new Map();
     this.previewToDocumentMap = new Map();
+    this.previewToSourceUriMap = new Map();
     // Clear all pending update timeouts
     this.updateTimeouts.forEach((timeout) => clearTimeout(timeout));
     this.updateTimeouts.clear();

--- a/test/current-preview-source.test.js
+++ b/test/current-preview-source.test.js
@@ -1,0 +1,156 @@
+/* global suite, test, suiteSetup, suiteTeardown */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const esbuild = require('esbuild');
+
+let resolveActivePreviewSource;
+let formatPreviewSourcePath;
+let tmpFile;
+
+suite('current-preview-source', function () {
+  this.timeout(15000);
+
+  suiteSetup(async function () {
+    const result = await esbuild.build({
+      entryPoints: [
+        path.join(__dirname, '..', 'src', 'current-preview-source.ts'),
+      ],
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: 'node18',
+      write: false,
+      logLevel: 'silent',
+    });
+    tmpFile = path.join(__dirname, '.current-preview-source.bundle.cjs');
+    fs.writeFileSync(tmpFile, result.outputFiles[0].text);
+    const mod = require(tmpFile);
+    resolveActivePreviewSource = mod.resolveActivePreviewSource;
+    formatPreviewSourcePath = mod.formatPreviewSourcePath;
+  });
+
+  suiteTeardown(function () {
+    if (tmpFile && fs.existsSync(tmpFile)) {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('returns the exact source of the active preview', function () {
+    const docsIndex = { path: '/workspace/docs/index.md' };
+    const apiIndex = { path: '/workspace/api/index.md' };
+
+    assert.strictEqual(
+      resolveActivePreviewSource([
+        { active: false, sourceUri: docsIndex },
+        { active: true, sourceUri: apiIndex },
+      ]),
+      apiIndex,
+    );
+  });
+
+  test('returns undefined when no preview is active', function () {
+    assert.strictEqual(
+      resolveActivePreviewSource([
+        { active: false, sourceUri: { path: '/workspace/a.md' } },
+      ]),
+      undefined,
+    );
+  });
+
+  test('returns undefined while the active preview source is unresolved', function () {
+    assert.strictEqual(
+      resolveActivePreviewSource([{ active: true, sourceUri: undefined }]),
+      undefined,
+    );
+  });
+
+  test('returns undefined instead of guessing between active previews', function () {
+    assert.strictEqual(
+      resolveActivePreviewSource([
+        { active: true, sourceUri: { path: '/workspace/a.md' } },
+        { active: true, sourceUri: { path: '/workspace/b.md' } },
+      ]),
+      undefined,
+    );
+  });
+
+  test('formats file URIs as filesystem paths', function () {
+    assert.strictEqual(
+      formatPreviewSourcePath({
+        scheme: 'file',
+        fsPath: '/workspace/docs/design.md',
+        toString: () => 'file:///workspace/docs/design.md',
+      }),
+      '/workspace/docs/design.md',
+    );
+  });
+
+  test('keeps the filesystem representation supplied for UNC file URIs', function () {
+    const uncPath = '\\\\server\\share\\docs\\design.md';
+
+    assert.strictEqual(
+      formatPreviewSourcePath({
+        scheme: 'file',
+        fsPath: uncPath,
+        toString: () => 'file://server/share/docs/design.md',
+      }),
+      uncPath,
+    );
+  });
+
+  test('preserves scheme and authority for non-file URIs', function () {
+    assert.strictEqual(
+      formatPreviewSourcePath(remoteUri()),
+      'vscode-remote://ssh-remote+example/workspace/docs/design.md',
+    );
+  });
+
+  test('drops the fragment and query of non-file URIs', function () {
+    assert.strictEqual(
+      formatPreviewSourcePath(remoteUri({ query: 'v=2', fragment: 'section' })),
+      'vscode-remote://ssh-remote+example/workspace/docs/design.md',
+    );
+  });
+
+  test('resolves file and non-file URIs to the same resource when a fragment is present', function () {
+    const withoutFragment = formatPreviewSourcePath(remoteUri());
+    const withFragment = formatPreviewSourcePath(
+      remoteUri({ fragment: 'section' }),
+    );
+    const fileUri = (fragment) => ({
+      scheme: 'file',
+      fsPath: '/workspace/docs/design.md',
+      with: () => fileUri(''),
+      toString: () =>
+        `file:///workspace/docs/design.md${fragment ? `#${fragment}` : ''}`,
+    });
+
+    assert.strictEqual(withFragment, withoutFragment);
+    assert.strictEqual(
+      formatPreviewSourcePath(fileUri('section')),
+      formatPreviewSourcePath(fileUri('')),
+    );
+  });
+});
+
+function remoteUri({ query = '', fragment = '' } = {}) {
+  return {
+    scheme: 'vscode-remote',
+    fsPath: '/workspace/docs/design.md',
+    with(change) {
+      return remoteUri({
+        query: change.query === undefined ? query : change.query,
+        fragment: change.fragment === undefined ? fragment : change.fragment,
+      });
+    },
+    toString() {
+      return (
+        'vscode-remote://ssh-remote+example/workspace/docs/design.md' +
+        (query ? `?${query}` : '') +
+        (fragment ? `#${fragment}` : '')
+      );
+    },
+  };
+}

--- a/test/preview-source-integration.test.js
+++ b/test/preview-source-integration.test.js
@@ -1,0 +1,265 @@
+/* global suite, test, suiteSetup, suiteTeardown, setup, teardown */
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const esbuild = require('esbuild');
+const {
+  recorder,
+  stubPlugin,
+  setWorkspaceFolderResolver,
+  setRelativePathResolver,
+  setMarkdownEngine,
+} = require('./vscode-stub');
+
+const RELATIVE_PATH_COMMAND =
+  'markdown-preview-enhanced.copyCurrentSourceRelativePath';
+const FULL_PATH_COMMAND = 'markdown-preview-enhanced.copyCurrentSourcePath';
+
+let bundle;
+let tmpFile;
+let provider;
+let openPanels;
+
+suite('preview source integration', function () {
+  this.timeout(30000);
+
+  suiteSetup(async function () {
+    const result = await esbuild.build({
+      stdin: {
+        contents: [
+          "export { initExtensionCommon } from './src/extension-common';",
+          "export { PreviewProvider, getActivePreviewSourceUri } from './src/preview-provider';",
+        ].join('\n'),
+        resolveDir: path.join(__dirname, '..'),
+        loader: 'ts',
+      },
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: 'node18',
+      write: false,
+      logLevel: 'silent',
+      plugins: [stubPlugin()],
+    });
+    tmpFile = path.join(__dirname, '.preview-source-integration.bundle.cjs');
+    fs.writeFileSync(tmpFile, result.outputFiles[0].text);
+    bundle = require(tmpFile);
+
+    await bundle.initExtensionCommon(makeExtensionContext());
+
+    // Register the provider the way the extension does, so that the commands
+    // reach it through the workspace-to-provider map.
+    setWorkspaceFolderResolver(() => ({ uri: makeUri('/ws') }));
+    provider = await bundle.PreviewProvider.getPreviewContentProvider(
+      makeUri('/ws/a.md'),
+      makeExtensionContext(),
+    );
+  });
+
+  suiteTeardown(function () {
+    if (tmpFile && fs.existsSync(tmpFile)) {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  setup(function () {
+    openPanels = [];
+    recorder.clipboard.text = null;
+    recorder.warnings = [];
+    setWorkspaceFolderResolver(() => undefined);
+    setRelativePathResolver((uri) => String(uri));
+    setMarkdownEngine(() => ({
+      generateHTMLTemplateForPreview: async () => '<html></html>',
+    }));
+  });
+
+  teardown(function () {
+    openPanels.forEach((panel) => panel.dispose());
+  });
+
+  test('publishes the rendered source once the preview is initialized', async function () {
+    const panel = makePanel();
+
+    assert.deepStrictEqual(provider.getPreviewSourceStates(), []);
+
+    await initPreview(provider, panel, '/ws/docs/design.md');
+
+    assert.deepStrictEqual(sourcePaths(provider), ['/ws/docs/design.md']);
+  });
+
+  test('publishes the destination after a link is followed inside the preview', async function () {
+    const panel = makePanel();
+
+    await initPreview(provider, panel, '/ws/a.md');
+    await initPreview(provider, panel, '/ws/subdir/c.md');
+
+    assert.deepStrictEqual(sourcePaths(provider), ['/ws/subdir/c.md']);
+  });
+
+  test('discards a render that lost the request race', async function () {
+    const panel = makePanel();
+    let releaseSlowRender;
+    const slowRenderStarted = new Promise((resolve) => {
+      setMarkdownEngine(() => ({
+        generateHTMLTemplateForPreview: async () => {
+          resolve();
+          await new Promise((r) => {
+            releaseSlowRender = r;
+          });
+          return '<html>stale</html>';
+        },
+      }));
+    });
+
+    const stale = initPreview(provider, panel, '/ws/slow.md');
+    await slowRenderStarted;
+
+    setMarkdownEngine(() => ({
+      generateHTMLTemplateForPreview: async () => '<html>fresh</html>',
+    }));
+    await initPreview(provider, panel, '/ws/fast.md');
+
+    releaseSlowRender();
+    await stale;
+
+    assert.deepStrictEqual(sourcePaths(provider), ['/ws/fast.md']);
+    assert.strictEqual(panel.webview.html, '<html>fresh</html>');
+  });
+
+  test('drops the source when the preview panel is disposed', async function () {
+    const panel = makePanel();
+
+    await initPreview(provider, panel, '/ws/a.md');
+    panel.dispose();
+
+    assert.deepStrictEqual(provider.getPreviewSourceStates(), []);
+    assert.strictEqual(bundle.getActivePreviewSourceUri(), undefined);
+  });
+
+  test('resolves nothing while no preview panel is focused', async function () {
+    const panel = makePanel({ active: false });
+
+    await initPreview(provider, panel, '/ws/a.md');
+
+    assert.strictEqual(bundle.getActivePreviewSourceUri(), undefined);
+  });
+
+  test('copies the full path of the focused preview source', async function () {
+    const panel = makePanel();
+
+    await initPreview(provider, panel, '/ws/docs/design.md');
+    await runCommand(FULL_PATH_COMMAND);
+
+    assert.strictEqual(recorder.clipboard.text, '/ws/docs/design.md');
+    assert.deepStrictEqual(recorder.warnings, []);
+  });
+
+  test('copies the workspace-relative path of the focused preview source', async function () {
+    const panel = makePanel();
+    setWorkspaceFolderResolver(() => ({ uri: { fsPath: '/ws' } }));
+    setRelativePathResolver((uri) => uri.path.replace('/ws/', ''));
+
+    await initPreview(provider, panel, '/ws/docs/design.md');
+    await runCommand(RELATIVE_PATH_COMMAND);
+
+    assert.strictEqual(recorder.clipboard.text, 'docs/design.md');
+    assert.deepStrictEqual(recorder.warnings, []);
+  });
+
+  test('warns instead of copying when no preview is focused', async function () {
+    const panel = makePanel({ active: false });
+
+    await initPreview(provider, panel, '/ws/a.md');
+    await runCommand(FULL_PATH_COMMAND);
+
+    assert.strictEqual(recorder.clipboard.text, null);
+    assert.strictEqual(recorder.warnings.length, 1);
+  });
+
+  test('warns instead of copying a relative path for a source outside the workspace', async function () {
+    const panel = makePanel();
+
+    await initPreview(provider, panel, '/elsewhere/a.md');
+    await runCommand(RELATIVE_PATH_COMMAND);
+
+    assert.strictEqual(recorder.clipboard.text, null);
+    assert.strictEqual(recorder.warnings.length, 1);
+  });
+});
+
+function makeExtensionContext() {
+  return {
+    subscriptions: [],
+    extensionUri: makeUri('/ext'),
+    extensionPath: '/ext',
+    extensionMode: 1,
+    globalState: { get: () => undefined, update: async () => {} },
+    workspaceState: { get: () => undefined, update: async () => {} },
+  };
+}
+
+function makeUri(fsPath) {
+  return {
+    scheme: 'file',
+    authority: '',
+    path: fsPath,
+    query: '',
+    fragment: '',
+    fsPath,
+    with() {
+      return this;
+    },
+    toString() {
+      return `file://${fsPath}`;
+    },
+  };
+}
+
+function makePanel({ active = true } = {}) {
+  const disposeHandlers = [];
+  const panel = {
+    active,
+    title: '',
+    iconPath: null,
+    options: {},
+    webview: {
+      html: '',
+      options: {},
+      asWebviewUri: (uri) => uri,
+      onDidReceiveMessage: () => ({ dispose() {} }),
+    },
+    onDidDispose(handler) {
+      disposeHandlers.push(handler);
+      return { dispose() {} };
+    },
+    dispose() {
+      disposeHandlers.forEach((handler) => handler());
+      disposeHandlers.length = 0;
+    },
+  };
+  openPanels.push(panel);
+  return panel;
+}
+
+async function initPreview(provider, panel, fsPath) {
+  const sourceUri = makeUri(fsPath);
+  await provider.initPreview({
+    sourceUri,
+    document: { uri: sourceUri, getText: () => '' },
+    webviewPanel: panel,
+    viewOptions: { viewColumn: 2 },
+  });
+}
+
+function sourcePaths(provider) {
+  return provider
+    .getPreviewSourceStates()
+    .map((state) => state.sourceUri && state.sourceUri.fsPath);
+}
+
+async function runCommand(commandId) {
+  const handler = recorder.commands.get(commandId);
+  assert.ok(handler, `command ${commandId} is not registered`);
+  await handler();
+}

--- a/test/vscode-stub.js
+++ b/test/vscode-stub.js
@@ -1,0 +1,222 @@
+/**
+ * Minimal in-memory stand-ins for the `vscode` and `crossnote` modules, used to
+ * bundle and exercise extension code that would otherwise only run inside an
+ * Extension Host.
+ *
+ * The stubs record what the extension did (registered commands, clipboard
+ * writes, warnings) so tests can assert on it.
+ */
+
+const recorder = {
+  commands: new Map(),
+  clipboard: { text: null },
+  warnings: [],
+  reset() {
+    this.commands = new Map();
+    this.clipboard = { text: null };
+    this.warnings = [];
+  },
+};
+
+const VSCODE_STUB_SOURCE = `
+  const recorder = globalThis.__vscodeStubRecorder;
+  const noop = () => {};
+  const disposable = { dispose: noop };
+  const event = () => disposable;
+
+  class Uri {
+    constructor(scheme, authority, path, query, fragment) {
+      this.scheme = scheme;
+      this.authority = authority;
+      this.path = path;
+      this.query = query || '';
+      this.fragment = fragment || '';
+    }
+    static file(path) {
+      return new Uri('file', '', path);
+    }
+    static parse(value) {
+      const m = /^([a-z][a-z0-9+.-]*):\\/\\/([^/?#]*)([^?#]*)(?:\\?([^#]*))?(?:#(.*))?$/i.exec(value);
+      return m ? new Uri(m[1], m[2], m[3], m[4], m[5]) : new Uri('file', '', value);
+    }
+    static joinPath(base, ...parts) {
+      return new Uri(base.scheme, base.authority, [base.path, ...parts].join('/'));
+    }
+    get fsPath() {
+      return this.path;
+    }
+    with(change) {
+      return new Uri(
+        change.scheme === undefined ? this.scheme : change.scheme,
+        change.authority === undefined ? this.authority : change.authority,
+        change.path === undefined ? this.path : change.path,
+        change.query === undefined ? this.query : change.query,
+        change.fragment === undefined ? this.fragment : change.fragment,
+      );
+    }
+    toString() {
+      return (
+        this.scheme + '://' + this.authority + this.path +
+        (this.query ? '?' + this.query : '') +
+        (this.fragment ? '#' + this.fragment : '')
+      );
+    }
+  }
+
+  module.exports = {
+    Uri,
+    ViewColumn: { One: 1, Two: 2, Beside: -2 },
+    window: {
+      createWebviewPanel: () => {
+        throw new Error('createWebviewPanel is not stubbed; pass a webviewPanel instead');
+      },
+      showErrorMessage: noop,
+      showWarningMessage: (message) => recorder.warnings.push(message),
+      showInformationMessage: noop,
+      showQuickPick: async () => undefined,
+      showInputBox: async () => undefined,
+      createOutputChannel: () => ({ appendLine: noop, show: noop, dispose: noop }),
+      createStatusBarItem: () => ({ show: noop, hide: noop, dispose: noop, text: '' }),
+      registerWebviewPanelSerializer: () => disposable,
+      registerCustomEditorProvider: () => disposable,
+      withProgress: async (_options, task) => task({ report: noop }, { isCancellationRequested: false }),
+      onDidChangeActiveTextEditor: event,
+      onDidChangeTextEditorSelection: event,
+      onDidChangeTextEditorVisibleRanges: event,
+      onDidChangeTextEditorViewColumn: event,
+      onDidChangeVisibleTextEditors: event,
+      onDidChangeActiveColorTheme: event,
+      onDidChangeWindowState: event,
+      visibleTextEditors: [],
+      activeTextEditor: undefined,
+      activeColorTheme: { kind: 1 },
+      tabGroups: { all: [], onDidChangeTabs: event, close: async () => true },
+    },
+    workspace: {
+      workspaceFolders: [],
+      textDocuments: [],
+      getConfiguration: () => ({ get: () => undefined, update: async () => {} }),
+      getWorkspaceFolder: (uri) => globalThis.__vscodeStubWorkspaceFolder(uri),
+      asRelativePath: (uri) => globalThis.__vscodeStubRelativePath(uri),
+      openTextDocument: async () => ({ getText: () => '', uri: Uri.file('/ws/a.md') }),
+      applyEdit: async () => true,
+      registerTextDocumentContentProvider: () => disposable,
+      createFileSystemWatcher: () => ({ onDidCreate: event, onDidChange: event, onDidDelete: event, dispose: noop }),
+      findFiles: async () => [],
+      fs: { readFile: async () => new Uint8Array(), writeFile: async () => {}, stat: async () => ({}) },
+      onDidChangeConfiguration: event,
+      onDidSaveTextDocument: event,
+      onDidChangeTextDocument: event,
+      onDidCloseTextDocument: event,
+      onDidOpenTextDocument: event,
+      onDidChangeWorkspaceFolders: event,
+      onDidCreateFiles: event,
+      onDidDeleteFiles: event,
+      onDidRenameFiles: event,
+    },
+    commands: {
+      executeCommand: async () => {},
+      registerCommand: (id, handler) => {
+        recorder.commands.set(id, handler);
+        return disposable;
+      },
+      registerTextEditorCommand: (id, handler) => {
+        recorder.commands.set(id, handler);
+        return disposable;
+      },
+    },
+    env: {
+      clipboard: {
+        writeText: async (text) => {
+          recorder.clipboard.text = text;
+        },
+        readText: async () => '',
+      },
+      openExternal: async () => true,
+      uriScheme: 'vscode',
+      appName: 'VS Code',
+    },
+    Position: class { constructor(line, character) { this.line = line; this.character = character; } },
+    Range: class { constructor(start, end) { this.start = start; this.end = end; } },
+    Selection: class { constructor(anchor, active) { this.anchor = anchor; this.active = active; } },
+    EventEmitter: class { constructor() { this.event = event; } fire() {} dispose() {} },
+    Disposable: class { static from() { return disposable; } dispose() {} },
+    WorkspaceEdit: class { insert() {} replace() {} delete() {} },
+    ExtensionMode: { Production: 1, Development: 2, Test: 3 },
+    ColorThemeKind: { Light: 1, Dark: 2 },
+    ProgressLocation: { Notification: 15 },
+    StatusBarAlignment: { Left: 1, Right: 2 },
+    TabInputCustom: class {},
+    TabInputText: class {},
+  };
+`;
+
+const CROSSNOTE_STUB_SOURCE = `
+  module.exports = {
+    Notebook: {
+      init: async ({ notebookPath, fs }) => ({
+        notebookPath,
+        config: {},
+        fs: { ...fs, exists: async () => false },
+        updateConfig: () => {},
+        getNoteMarkdownEngine: () => globalThis.__crossnoteStubEngine(),
+        clearAllNoteMarkdownEngineCaches: () => {},
+      }),
+    },
+    PreviewMode: {
+      SinglePreview: 'Single Preview',
+      MultiplePreviews: 'Multiple Previews',
+      PreviewsOnly: 'Previews Only',
+    },
+    utility: {
+      getCrossnoteBuildDirectory: () => '/tmp/crossnote',
+      setCrossnoteBuildDirectory: () => {},
+      useExternalAddFileProtocolFunction: () => {},
+      addFileProtocol: (value) => value,
+      escapeString: (value) => value,
+      unescapeString: (value) => value,
+    },
+    ImageUploader: {},
+    getDefaultNotebookConfig: () => ({}),
+    loadConfigsInDirectory: async () => ({}),
+  };
+`;
+
+/** esbuild plugin that resolves `vscode` and `crossnote` to the stubs above. */
+function stubPlugin() {
+  return {
+    name: 'vscode-crossnote-stub',
+    setup(build) {
+      build.onResolve({ filter: /^(vscode|crossnote)$/ }, (args) => ({
+        path: args.path,
+        namespace: 'extension-stub',
+      }));
+      build.onLoad({ filter: /.*/, namespace: 'extension-stub' }, (args) => ({
+        contents:
+          args.path === 'vscode' ? VSCODE_STUB_SOURCE : CROSSNOTE_STUB_SOURCE,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+globalThis.__vscodeStubRecorder = recorder;
+globalThis.__vscodeStubWorkspaceFolder = () => undefined;
+globalThis.__vscodeStubRelativePath = (uri) => String(uri);
+globalThis.__crossnoteStubEngine = () => ({
+  generateHTMLTemplateForPreview: async () => '<html></html>',
+});
+
+module.exports = {
+  recorder,
+  stubPlugin,
+  setWorkspaceFolderResolver(fn) {
+    globalThis.__vscodeStubWorkspaceFolder = fn;
+  },
+  setRelativePathResolver(fn) {
+    globalThis.__vscodeStubRelativePath = fn;
+  },
+  setMarkdownEngine(fn) {
+    globalThis.__crossnoteStubEngine = fn;
+  },
+};


### PR DESCRIPTION
## Summary

Two new commands copy the Markdown file the focused preview is **actually rendering** — `Markdown Preview Enhanced: Copy Current Source Path` (full path / URI) and `Copy Current Source Relative Path` (workspace-relative).

## Problem

Following a link inside the preview (`a.md` → `b.md` → `subdir/c.md`) leaves the preview and the editor resource it was opened from out of sync, so VS Code's built-in **Copy Path** / **Copy Relative Path** can copy a different file than the one on screen — most visibly with `"previewMode": "Previews Only"`, where the preview *is* the tab and no text editor is open. The tab title only carries a basename, which is ambiguous across `docs/index.md`, `guide/index.md`, …

## Relationship to #2235

[#2235](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2235) (stale breadcrumb) is the same drift seen from the other side. Fixing it would make the built-in Copy Path correct in `Previews Only`, but not in `Single Preview` / `Multiple Previews`, where the preview is a webview panel with no editor resource to correct. Conversely, the per-panel source map added here is what a fix for #2235 needs — happy to follow up on that issue on top of this if you'd prefer that direction.

## How it works

- `PreviewProvider` records, per `WebviewPanel`, the source URI whose HTML is installed — published only after the render wins the request race, cleared on disposal and provider resets, so a panel never advertises a source it is not showing.
- The commands read the source of the *single* active panel. No active preview, two active previews, or a panel that hasn't rendered yet → a warning, nothing copied. There is deliberately no fallback to basename matching, the tab title, `activeTextEditor`, a workspace search, or the URI the preview was opened with: each is stale or ambiguous in exactly these cases, and copying the wrong path silently is worse than copying nothing.
- `file:` sources use `Uri.fsPath` (Windows drive letters and UNC spellings preserved); other schemes use `Uri.toString()` minus query and fragment, so a link hop to `…/b.md#section` still yields the source resource. A relative path is only produced for sources inside the workspace.
- Resolution and formatting live in `src/current-preview-source.ts` behind structural interfaces, so they are testable without the `vscode` module.

## Testing

`pnpm test` — 76 passing, 18 of them new: unit tests for the resolver/formatter, plus integration tests driving the real `PreviewProvider` through a `vscode` stub (panel lifecycle, link hops, race loser discarded, disposal, clipboard contents). `pnpm check:all` and `tsc --noEmit` are clean.

Manually verified in the Extension Development Host: direct open, one link hop, and several link hops. Not verified by hand: duplicate basenames, `Previews Only`, and remote/UNC URI spellings (covered by the integration tests only).
