### PR TITLE
fix: restore extension activation on Node 18 hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug fixes
+
+- **Restore extension activation on Node.js 18-based VS Code releases** — pin crossnote's HTML parser to the compatible `cheerio` 1.0.0 release instead of resolving `cheerio` 1.2.0 / `undici` 7, which failed with `ReferenceError: File is not defined` before commands were registered. The extension now declares VS Code 1.86 as its minimum supported version, matching its Node.js 18.17 runtime requirement.
+
 ## [0.8.34] - 2026-09-06
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "run-in-browser:watch": "node build.js --web-dev && concurrently \"vscode-test-web --browser none --extensionDevelopmentPath=. ${SERVE_DIR:-.}\" \"npx http-server ./crossnote -p 6789 --cors\" \"node build.js --watch\"",
     "run-in-vscode-dev": "npx serve --cors -l 5000 --ssl-cert $HOME/certs/localhost.pem --ssl-key $HOME/certs/localhost-key.pem",
     "test": "pnpm test:unit",
-    "test:unit": "mocha --ui tdd --reporter spec test/find-fragment-target-line.test.js test/block-id-helpers.test.js test/rank-by-closeness.test.js test/current-preview-source.test.js test/preview-source-integration.test.js",
+    "test:unit": "mocha --ui tdd --reporter spec test/native-runtime-compat.test.js test/find-fragment-target-line.test.js test/block-id-helpers.test.js test/rank-by-closeness.test.js test/current-preview-source.test.js test/preview-source-integration.test.js",
     "vscode:prepublish": "pnpm install --frozen-lockfile && pnpm build",
     "watch": "gulp copy-files && gulp clean-out && node build.js --watch"
   },
@@ -988,10 +988,11 @@
     "webpack-cli": "^5.1.4"
   },
   "engines": {
-    "vscode": "^1.70.0"
+    "vscode": "^1.86.0"
   },
   "pnpm": {
     "overrides": {
+      "crossnote>cheerio": "1.0.0",
       "less": "4.2.2"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  crossnote>cheerio: 1.0.0
   less: 4.2.2
 
 importers:
@@ -1664,9 +1665,9 @@ packages:
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
-  cheerio@1.2.0:
-    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
-    engines: {node: '>=20.18.1'}
+  cheerio@1.0.0:
+    resolution: {integrity: sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==}
+    engines: {node: '>=18.17'}
 
   chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
@@ -2330,10 +2331,6 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  entities@7.0.1:
-    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
-    engines: {node: '>=0.12'}
-
   envinfo@7.21.0:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
@@ -2970,11 +2967,11 @@ packages:
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
-  htmlparser2@10.1.0:
-    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
-
   htmlparser2@9.0.0:
     resolution: {integrity: sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==}
+
+  htmlparser2@9.1.0:
+    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
@@ -5218,9 +5215,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.29.0:
-    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
-    engines: {node: '>=20.18.1'}
+  undici@6.28.1:
+    resolution: {integrity: sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==}
+    engines: {node: '>=18.17'}
 
   unescape@1.0.1:
     resolution: {integrity: sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==}
@@ -7264,18 +7261,18 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
 
-  cheerio@1.2.0:
+  cheerio@1.0.0:
     dependencies:
       cheerio-select: 2.1.0
       dom-serializer: 2.0.0
       domhandler: 5.0.3
       domutils: 3.2.2
       encoding-sniffer: 0.2.1
-      htmlparser2: 10.1.0
+      htmlparser2: 9.1.0
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.29.0
+      undici: 6.28.1
       whatwg-mimetype: 4.0.0
 
   chokidar@2.1.8:
@@ -7518,7 +7515,7 @@ snapshots:
       async-mutex: 0.4.1
       bit-field: 1.9.0
       case-anything: 2.1.13
-      cheerio: 1.2.0
+      cheerio: 1.0.0
       chrome-paths: 1.0.1
       classnames: 2.5.1
       copy-anything: 3.0.5
@@ -8054,8 +8051,6 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
-
-  entities@7.0.1: {}
 
   envinfo@7.21.0: {}
 
@@ -8918,14 +8913,14 @@ snapshots:
 
   html-to-image@1.11.13: {}
 
-  htmlparser2@10.1.0:
+  htmlparser2@9.0.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.2.2
-      entities: 7.0.1
+      entities: 4.5.0
 
-  htmlparser2@9.0.0:
+  htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
@@ -11442,7 +11437,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.29.0: {}
+  undici@6.28.1: {}
 
   unescape@1.0.1:
     dependencies:

--- a/test/native-runtime-compat.test.js
+++ b/test/native-runtime-compat.test.js
@@ -1,0 +1,26 @@
+/* global suite, test */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+suite('native runtime compatibility', function () {
+  test('loads crossnote HTML parsing without a global File constructor', function () {
+    const script = `
+      const { createRequire } = require('module');
+      delete globalThis.File;
+      const requireFromCrossnote = createRequire(require.resolve('crossnote'));
+      requireFromCrossnote('cheerio');
+    `;
+    const result = spawnSync(process.execPath, ['-e', script], {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(
+      result.status,
+      0,
+      [result.stderr, result.stdout].filter(Boolean).join('\n'),
+    );
+  });
+});

--- a/test/native-runtime-compat.test.js
+++ b/test/native-runtime-compat.test.js
@@ -5,12 +5,16 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 suite('native runtime compatibility', function () {
-  test('loads crossnote HTML parsing without a global File constructor', function () {
+  test('parses HTML with crossnote cheerio without a global File constructor', function () {
     const script = `
+      const assert = require('assert');
       const { createRequire } = require('module');
-      delete globalThis.File;
+      assert.strictEqual(Reflect.deleteProperty(globalThis, 'File'), true);
+      assert.strictEqual(typeof globalThis.File, 'undefined');
       const requireFromCrossnote = createRequire(require.resolve('crossnote'));
-      requireFromCrossnote('cheerio');
+      const cheerio = requireFromCrossnote('cheerio');
+      const $ = cheerio.load('<main><h1>Preview</h1></main>');
+      assert.strictEqual($('h1').text(), 'Preview');
     `;
     const result = spawnSync(process.execPath, ['-e', script], {
       cwd: path.join(__dirname, '..'),


### PR DESCRIPTION
## Summary

- Pin Crossnote's Cheerio dependency to 1.0.0 so the native extension loads on Node.js 18.17.
- Declare VS Code 1.86 as the minimum supported release, matching that runtime floor.
- Add a regression test and changelog entry.

## Root cause

The pnpm migration resolved Crossnote's `^1.0.0-rc.12` Cheerio range to Cheerio 1.2.0 and Undici 7, which require Node.js 20.18.1. VS Code 1.86.2 uses Node.js 18.17.1 and does not provide a global `File`, so extension loading failed with `ReferenceError: File is not defined` before commands were registered.

The override is scoped to `crossnote>cheerio`; it does not change Crossnote for other consumers. The upstream fix is shd101wyy/crossnote#494, tracking shd101wyy/crossnote#493. Once that fix is released and adopted here, this extension-level override can be removed.

## Validation

- `pnpm check:all` (0 errors; existing warnings only)
- `pnpm test` (77 passing)
- `pnpm exec tsc --noEmit`
- `pnpm build` (native and web bundles)
- Loaded the fixed Cheerio resolution with `File` absent under VS Code 1.86.2's Node.js 18.17.1 runtime
