### PR TITLE
fix: reveal existing preview panel when openPreview asks for focus

### DIFF
--- a/src/preview-provider.ts
+++ b/src/preview-provider.ts
@@ -522,6 +522,13 @@ export class PreviewProvider {
       } else {
         previewPanel = PreviewProvider.singlePreviewPanel;
         PreviewProvider.singlePreviewPanelSourceUriTarget = sourceUri;
+        // The panel already exists, so reusing it below never brings it to the
+        // foreground the way createWebviewPanel does for a brand-new panel.
+        // Honor preserveFocus so `openPreview` (preserveFocus=false) focuses
+        // the preview again, while side/locked previews keep the editor focus.
+        if (!viewOptions.preserveFocus) {
+          previewPanel.reveal();
+        }
       }
     } else if (previews && previews.length > 0 && !webviewPanel) {
       await Promise.all(
@@ -536,6 +543,11 @@ export class PreviewProvider {
           }),
         ),
       );
+      // Same reuse caveat as above: after refreshing the existing previews,
+      // surface the first one when the caller asked for focus.
+      if (!viewOptions.preserveFocus) {
+        previews[0].reveal();
+      }
       return;
     } else {
       const buildDir = utility.getCrossnoteBuildDirectory();


### PR DESCRIPTION
### Problem

When a preview panel for the file **already exists**, re-invoking `markdown-preview-enhanced.openPreview` (or its keyboard shortcut) only refreshes the preview content but **never switches focus to the preview panel**.

A brand-new panel created via `createWebviewPanel` is focused automatically when `preserveFocus` is `false`, but the two reuse paths in `initPreview` skip that behavior:

- **SinglePreview mode**: an existing panel is reused at `preview-provider.ts` (~line 522) without being revealed.
- **MultiplePreviews mode**: existing panels are refreshed via `Promise.all(...)` and then `return`ed at `preview-provider.ts` (~line 526) without revealing any of them.

### Fix

In both reuse paths, call `reveal()` when `viewOptions.preserveFocus` is `false`, so re-opening behaves the same as opening for the first time. Side / locked previews pass `preserveFocus: true` and remain unaffected (they keep the editor focus, matching the #2286 behavior).

### Verification

- `tsc -p tsconfig.json --noEmit` passes
- `eslint src/preview-provider.ts` and `prettier --check src/preview-provider.ts` pass
- `pnpm build` succeeds; the compiled `out/native/extension.js` contains both reveal calls

### Notes

This bug is also worked around client-side via a runtime patch (see https://github.com/Li-Mingshuang/ai-skill-mde-focus-fix) which breaks on every extension upgrade — landing the fix upstream would remove that maintenance burden.
