### PR TITLE
ci: retry the Marketplace publish and make release re-runs idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,62 +79,100 @@ jobs:
           version: ${{ steps.bump.outputs.new-version }}
           path: "CHANGELOG.md"
 
+      # Packaged once, published to both registries from the same file — byte
+      # identical on the Marketplace and Open VSX. vsce runs the
+      # `vscode:prepublish` script (frozen install + build) again here; that
+      # is slower but keeps packaging independent of the steps above.
+      - name: Package the extension
+        id: package
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+        run: |
+          VSIX="markdown-preview-enhanced-${NEW_VERSION}.vsix"
+          npx --yes @vscode/vsce@3.9.2 package --out "$VSIX"
+          echo "vsixPath=$VSIX" >> "$GITHUB_OUTPUT"
+
+      # The gallery publish regularly times out inside vsce's ~3-minute
+      # request budget while the Marketplace's server-side validation step is
+      # slow (observed for hours on 2026-09-08). Retry the publish instead of
+      # failing once, and treat "version already exists" as success — a
+      # previous attempt may have completed server-side despite the client
+      # timeout, and recovery re-runs must stay green.
       - name: Publish extension to Visual Studio Marketplace
-        id: create_vsix
-        # A marketplace publish failure (e.g. an expired/missing
-        # VS_MARKETPLACE_TOKEN) must not fail the workflow: the vsix is still
-        # packaged (vsixPath is set before publishing), so Open VSX, the
-        # GitHub release, and the vsix attachment all proceed. Update the
-        # VS_MARKETPLACE_TOKEN secret and re-run this workflow to retry the
-        # publish; skipDuplicate makes re-runs safe for already-published
-        # versions.
+        id: marketplace_publish
         continue-on-error: true
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: nick-fields/retry@v3
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new-version }}
+          VSIX: ${{ steps.package.outputs.vsixPath }}
+          VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
-          dependencies: false
-          skipDuplicate: true
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 90
+          command: |
+            if curl -sf -X POST 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery' \
+                 -H 'Content-Type: application/json' \
+                 -H 'Accept: application/json;api-version=7.2-preview.1' \
+                 -d '{"filters":[{"criteria":[{"filterType":7,"value":"shd101wyy.markdown-preview-enhanced"}]}],"flags":215}' \
+                 | grep -q "\"version\":\"$NEW_VERSION\""; then
+              echo "$NEW_VERSION is already published to the Marketplace — skipping."
+              exit 0
+            fi
+            npx --yes @vscode/vsce@3.9.2 publish --packagePath "$VSIX" -p "$VS_MARKETPLACE_TOKEN"
 
       - name: Publish extension to Open VSX
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           registryUrl: https://open-vsx.org
-          extensionFile: ${{ steps.create_vsix.outputs.vsixPath }}
+          extensionFile: ${{ steps.package.outputs.vsixPath }}
           dependencies: false
           # Keeps workflow re-runs green when the version is already published.
           skipDuplicate: true
 
-      - name: Warn about Visual Studio Marketplace publish failure
-        if: steps.create_vsix.outcome == 'failure'
+      # ::error (not ::warning) so a tolerated publish failure cannot hide in
+      # a green-looking run — continue-on-error marks the step itself green at
+      # the job level, the annotation is the only visible trace.
+      - name: Report Marketplace publish failure
+        if: steps.marketplace_publish.outcome == 'failure'
         run: |
-          echo "::warning::Publishing to the Visual Studio Marketplace failed (often caused by an invalid or missing VS_MARKETPLACE_TOKEN). Everything else succeeded."
-          echo "::warning::To retry: update the VS_MARKETPLACE_TOKEN secret, then re-run this workflow. Already-published versions are skipped (skipDuplicate)."
+          echo "::error::Publishing to the Visual Studio Marketplace failed after 3 attempts (usually the gallery's server-side validation timing out). Everything else succeeded — Open VSX and the GitHub Release are live."
+          echo "::error::To retry once the Marketplace recovers: re-run this workflow run. Already-published versions are detected and skipped, and re-runs stay green."
 
+      # Idempotent across re-runs: on a publish-retry re-run the tag (and the
+      # release branch/PR from the first attempt) already exist — skip the
+      # bookkeeping instead of failing on the existing tag.
       - name: Commit, tag and push the release branch
+        id: release_branch
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
         run: |
           git add package.json CHANGELOG.md
           git commit -m "$NEW_VERSION"
-          git tag "$NEW_VERSION"
-          # master is branch-protected and slated for deprecation — the
-          # release commit lives on release/v<version> and merges back to
-          # develop via the PR below; a direct push to master is both
-          # rejected (GH006) and unnecessary.
-          git push origin "HEAD:refs/heads/release/v$NEW_VERSION"
-          git push origin "refs/tags/$NEW_VERSION"
+          if git rev-parse -q --verify "refs/tags/$NEW_VERSION" >/dev/null; then
+            echo "tag $NEW_VERSION already exists — publish retry, skipping branch/tag push"
+            echo "first_run=false" >> "$GITHUB_OUTPUT"
+          else
+            # master is branch-protected and slated for deprecation — the
+            # release commit lives on release/v<version> and merges back to
+            # develop via the PR below; a direct push to master is both
+            # rejected (GH006) and unnecessary.
+            git tag "$NEW_VERSION"
+            git push origin "HEAD:refs/heads/release/v$NEW_VERSION"
+            git push origin "refs/tags/$NEW_VERSION"
+            echo "first_run=true" >> "$GITHUB_OUTPUT"
+          fi
 
       # Idempotent across workflow re-runs: an existing release is kept and
       # only the vsix asset is (re-)uploaded, so retrying a marketplace
-      # publish after updating VS_MARKETPLACE_TOKEN stays green.
+      # publish stays green.
       - name: Create or update GitHub Release
-        if: steps.create_vsix.outputs.vsixPath != ''
+        if: steps.package.outputs.vsixPath != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
-          VSIX_PATH: ${{ steps.create_vsix.outputs.vsixPath }}
+          VSIX_PATH: ${{ steps.package.outputs.vsixPath }}
           RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
         run: |
           echo "$RELEASE_NOTES" > "$RUNNER_TEMP/release-notes.md"
@@ -146,7 +184,10 @@ jobs:
           fi
           gh release upload "$NEW_VERSION" "$VSIX_PATH" --clobber
 
+      # Only on a first run: a publish-retry re-run reuses the tag, release
+      # and PR that the original attempt already created and merged.
       - name: Open auto-merge PR back to develop
+        if: steps.release_branch.outputs.first_run == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}
@@ -160,6 +201,7 @@ jobs:
       # develop requires 1 approving review; the bot can't approve its own PR,
       # so RELEASE_TOKEN (a PAT of the maintainer) supplies the approval
       - name: Approve and auto-merge the release PR
+        if: steps.release_branch.outputs.first_run == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NEW_VERSION: ${{ steps.bump.outputs.new-version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ What the workflow does, in order:
 1. Runs `pnpm run check:all`, `pnpm test`, and `pnpm run build`
 2. Bumps `package.json` (`npm version <level>`)
 3. Rewrites `CHANGELOG.md`: renames `## [Unreleased]` to `## [X.Y.Z] - <today>` and prepends a fresh empty `## [Unreleased]` section — **write changelog entries under `[Unreleased]` before dispatching a release**
-4. Publishes to the Visual Studio Marketplace (tolerated failure — re-run after fixing `VS_MARKETPLACE_TOKEN`; `skipDuplicate` keeps re-runs safe) and Open VSX
-5. Commits the bump + changelog on a `release/vX.Y.Z` branch, tags it, pushes the branch + tag, creates/updates the GitHub Release with the `.vsix` attached (master is deprecated and not pushed to)
+4. Packages the `.vsix` once, then publishes it to the Visual Studio Marketplace (up to **3 attempts** around vsce's ~3-minute request timeout — the gallery's server-side validation step stalls for hours at a time; "version already exists" counts as success so recovery re-runs stay green; a failure after all attempts is **tolerated** and surfaces as an `::error` annotation, not a failed run) and Open VSX (`skipDuplicate` keeps re-runs safe). To retry a failed Marketplace publish once the gallery recovers: `gh run rerun <run-id>` — re-runs reuse the original ref and inputs (same version), skip already-published targets, and skip the tag/release/PR bookkeeping that the first attempt already completed. Do **not** dispatch a fresh run to retry a publish — it would bump a new version.
+5. Commits the bump + changelog on a `release/vX.Y.Z` branch, tags it, pushes the branch + tag (idempotent: skipped when the tag already exists), creates/updates the GitHub Release with the `.vsix` attached (master is deprecated and not pushed to)
 6. Opens a `release/vX.Y.Z` → `develop` PR, approves it via the `RELEASE_TOKEN` secret, and auto-merges it
 
 ### Changelog content


### PR DESCRIPTION
## Summary

Today's 0.8.35 release exposed two workflow problems: the Marketplace publish timed out reproducibly inside vsce's ~3-minute request budget (the gallery's server-side validation stalled for hours), and the tolerated-failure design hid it — `continue-on-error` marks the step green at the job level and the follow-up used `::warning`, so the run looked fully green with the failure buried in the log (caught only by eyeballing the marketplace).

- **Package once, publish twice** — a `vsce package` step produces the `.vsix`; both registries publish that identical file (Marketplace via the vsce CLI, Open VSX unchanged on HaaLeo with `skipDuplicate`).
- **Marketplace publish retries** — up to 3 attempts with 90 s backoff (`nick-fields/retry@v3`). Each attempt first queries the gallery API and exits 0 if the version is already published, so a server-side success after a client-side timeout counts as success and recovery re-runs can't fail on duplicates.
- **Tolerated failures are loud** — after all attempts the annotation is `::error`, not `::warning`.
- **Idempotent bookkeeping** — the tag/branch push skips itself when the tag exists (kills the `fatal: tag '0.8.35' already exists` red from re-runs), and the release-PR steps are gated to first runs only, so a publish-retry re-run is fully green.
- **AGENTS.md** documents the retry/re-run contract, including the rule to retry publishes with `gh run rerun` and never a fresh dispatch.

## Testing

- [x] YAML parses (18 steps, structure verified step by step)
- [x] Prettier clean
- [x] Re-run path traced by hand against today's actual 0.8.35 state (tag exists, PR merged): publish → already-published/skip or fresh publish, tag step skips, release re-upload clobbers, PR steps skip → green
- [ ] CI on this PR (unit checks only; `release.yml` is `workflow_dispatch`-gated so this cannot trigger a release)
